### PR TITLE
Add tracking, cell division and new cell detection functionality for training and inference

### DIFF
--- a/adapters/sam2_lora_model.py
+++ b/adapters/sam2_lora_model.py
@@ -19,6 +19,7 @@ class SAM2LoRAModel:
         adapt_mlp=True,
         trainable_iou_pred_heads=True,
         trainable_obj_score_heads=True,
+        mode='train',
     ):
         self.model = model
         self.lora_rank = lora_rank
@@ -31,7 +32,7 @@ class SAM2LoRAModel:
         self.adapt_mlp = adapt_mlp
         self.trainable_iou_pred_heads = trainable_iou_pred_heads
         self.trainable_obj_score_heads = trainable_obj_score_heads
-
+        self.mode = mode
         self.inject()
 
     def create_adapter(self, blk, dim):
@@ -122,29 +123,31 @@ class SAM2LoRAModel:
             adapter_name = 'lora/sam_mask_decoder/transformer/final_attn_token_to_image'
             self.model.sam_mask_decoder.transformer.final_attn_token_to_image = self.inject_lora_to_rope_attention(self.model.sam_mask_decoder.transformer.final_attn_token_to_image, adapter_name)
 
-        # Freeze all parameters by default
-        for param in self.model.parameters():
-            param.requires_grad = False
+        if self.mode == 'train':
+            # Freeze all parameters by default
+            for param in self.model.parameters():
+                param.requires_grad = False
 
-        # Unfreeze LoRA parameters and optionally prediction heads
-        trainable_patterns = ['lora', 'div']
-        if self.trainable_iou_pred_heads:
-            trainable_patterns.append('iou_prediction_head')
-        if self.trainable_obj_score_heads:
-            trainable_patterns.append('pred_obj_score_head')
+            # Unfreeze LoRA parameters and optionally prediction heads
+            trainable_patterns = ['lora', 'div', 'no_mem_', 'no_obj_', ' maskmem_tpos_enc']
 
-        if not self.adapt_encoder:
-            trainable_patterns.append('image_encoder')
-        if not self.adapt_memory:
-            trainable_patterns.append('memory_encoder')
-        if not self.adapt_decoder:
-            trainable_patterns.append('sam_mask_decoder')
+            if self.trainable_iou_pred_heads:
+                trainable_patterns.append('iou_prediction_head')
+            if self.trainable_obj_score_heads:
+                trainable_patterns.append('pred_obj_score_head')
 
-        for name, param in self.model.named_parameters():
-            if any(pattern in name.lower() for pattern in trainable_patterns):
-                param.requires_grad = True
+            if not self.adapt_encoder:
+                trainable_patterns.append('image_encoder')
+            if not self.adapt_memory:
+                trainable_patterns.append('memory_encoder')
+            if not self.adapt_decoder:
+                trainable_patterns.append('sam_mask_decoder')
 
-        self.print_trainable()
+            for name, param in self.model.named_parameters():
+                if any(pattern in name.lower() for pattern in trainable_patterns):
+                    param.requires_grad = True
+
+            self.print_trainable()
 
     def save_adapters(self, save_dir):
 

--- a/adapters/sam2_lora_model.py
+++ b/adapters/sam2_lora_model.py
@@ -129,7 +129,7 @@ class SAM2LoRAModel:
                 param.requires_grad = False
 
             # Unfreeze LoRA parameters and optionally prediction heads
-            trainable_patterns = ['lora', 'div', 'no_mem_', 'no_obj_', ' maskmem_tpos_enc']
+            trainable_patterns = ['lora', 'div', 'no_mem_', 'no_obj_', ' maskmem_tpos_enc', 'feature_dim_reducers', 'heatmap_predictor']
 
             if self.trainable_iou_pred_heads:
                 trainable_patterns.append('iou_prediction_head')

--- a/adapters/sam2_lora_model.py
+++ b/adapters/sam2_lora_model.py
@@ -127,7 +127,7 @@ class SAM2LoRAModel:
             param.requires_grad = False
 
         # Unfreeze LoRA parameters and optionally prediction heads
-        trainable_patterns = ['lora']
+        trainable_patterns = ['lora', 'div']
         if self.trainable_iou_pred_heads:
             trainable_patterns.append('iou_prediction_head')
         if self.trainable_obj_score_heads:

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -180,7 +180,7 @@ class SAM2AutomaticCellTracker:
         # (we directly use their consolidated outputs during tracking)
         # metadata for each tracking frame (e.g. which direction it's tracked)
         inference_state["frames_tracked_per_obj"] = {}
-        inference_state["memory_dict"] = {}
+        inference_state["memory_dict"] = {"mask_mem_pos_enc": None}
         # Warm up the visual backbone and cache the image feature on frame 0
         self._get_image_feature(inference_state, frame_idx=0, batch_size=1)
 

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -804,7 +804,7 @@ class SAM2AutomaticCellTracker:
         if len(cell_ids) > 0:
             assert max(cell_ids) < 65536, "cell_id must be less than 65536"
 
-        cv2.imwrite(str(res_path / f'mask_{frame_idx:03d}.tif'), track_mask.astype(np.uint16))
+        cv2.imwrite(str(res_path / f'mask{frame_idx:03d}.tif'), track_mask.astype(np.uint16))
 
         if not self.segment:
 

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -1,0 +1,677 @@
+import numpy as np
+import torch
+from tqdm import tqdm
+from torchvision.ops import batched_nms
+import cv2
+
+from sam2.modeling.sam2_base import SAM2Base
+from sam2.utils.amg import (
+    batch_iterator, 
+    batched_mask_to_box, 
+    calculate_stability_score, 
+    MaskData, 
+    area_from_rle, 
+    box_xyxy_to_xywh, 
+    mask_to_rle_pytorch, 
+    coco_encode_rle, 
+    rle_to_mask
+)
+from sam2.utils.misc import load_video_frames
+from sam2.utils.transforms import SAM2Transforms
+
+
+class SAM2AutomaticCellTracker:
+    def __init__(
+        self,
+        model: SAM2Base,
+        points_per_side: int = 32,
+        points_per_batch: int = 32,
+        obj_score_thresh: float = 0,
+        pred_iou_thresh: float = 0.7,
+        div_obj_score_thresh: float = 0,
+        stability_score_thresh: float = 0,
+        stability_score_offset: float = 1.0,
+        box_nms_thresh: float = 0.7,
+        min_mask_region_area: int = 10,
+        output_mode: str = "binary_mask",
+        use_m2m: bool = False,
+        max_hole_area: int = 0,
+        max_sprinkle_area: int = 0,
+        mask_threshold: float = 0.0,
+    ) -> None:
+        """
+        Using a SAM 2 model, generates and tracks masks for an entire video.
+        Generates a grid of point prompts over the first frame, then tracks the detected cells
+        throughout the video.
+
+        Arguments:
+          model (Sam): The SAM 2 model to use for mask prediction.
+          points_per_side (int): The number of points to be sampled
+            along one side of the image. The total number of points is
+            points_per_side**2.
+          points_per_batch (int): Sets the number of points run simultaneously
+            by the model. Higher numbers may be faster but use more GPU memory.
+          pred_iou_thresh (float): A filtering threshold in [0,1], using the
+            model's predicted mask quality.
+          stability_score_thresh (float): A filtering threshold in [0,1], using
+            the stability of the mask under changes to the cutoff used to binarize
+            the model's mask predictions.
+          stability_score_offset (float): The amount to shift the cutoff when
+            calculated the stability score.
+          mask_threshold (float): Threshold for binarizing the mask logits
+          box_nms_thresh (float): The box IoU cutoff used by non-maximal
+            suppression to filter duplicate masks.
+          min_mask_region_area (int): If >0, postprocessing will be applied
+            to remove disconnected regions and holes in masks with area smaller
+            than min_mask_region_area. Requires opencv.
+          output_mode (str): The form masks are returned in. Can be 'binary_mask',
+            'uncompressed_rle', or 'coco_rle'. 'coco_rle' requires pycocotools.
+            For large resolutions, 'binary_mask' may consume large amounts of
+            memory.
+          use_m2m (bool): Whether to add a one step refinement using previous mask predictions.
+          multimask_output (bool): Whether to output multimask at each point of the grid.
+        """
+
+        assert output_mode in [
+            "binary_mask",
+            "uncompressed_rle",
+            "coco_rle",
+        ], f"Unknown output_mode {output_mode}."
+        if output_mode == "coco_rle":
+            try:
+                from pycocotools import mask as mask_utils  # type: ignore  # noqa: F401
+            except ImportError as e:
+                print("Please install pycocotools")
+                raise e
+            
+        self.model = model
+        self.model.sam_mask_decoder.pred_iou_thresh = pred_iou_thresh
+        self.model.sam_mask_decoder.obj_score_thresh = obj_score_thresh
+        self.model.sam_mask_decoder.div_obj_score_thresh = div_obj_score_thresh
+        self.device = model.device
+
+        if self.device.type == 'cpu':
+            min_mask_region_area = 0
+
+        self.points_per_side = points_per_side
+        self.points_per_batch = points_per_batch
+        self.stability_score_thresh = stability_score_thresh
+        self.stability_score_offset = stability_score_offset
+        self.mask_threshold = mask_threshold
+        self.box_nms_thresh = box_nms_thresh
+        self.output_mode = output_mode
+        self.use_m2m = use_m2m
+        self.obj_score_thresh = obj_score_thresh
+
+        self.pred_iou_thresh = pred_iou_thresh
+        self.obj_score_thresh = obj_score_thresh
+        self.div_obj_score_thresh = div_obj_score_thresh
+
+        self._transforms = SAM2Transforms(
+            resolution=self.model.image_size,
+            mask_threshold=mask_threshold,
+            max_hole_area=max_hole_area,
+            max_sprinkle_area=max_sprinkle_area,
+        )
+
+    @torch.inference_mode()
+    def init_state(
+        self,
+        video_path,
+        res_path,
+        offload_video_to_cpu=False,
+        offload_state_to_cpu=False,
+        async_loading_frames=False,
+    ):
+        """Initialize an inference state."""
+        compute_device = self.model.device  # device of the model
+        images, video_height, video_width, resized_image_size, padding = load_video_frames(
+            video_path=video_path,
+            image_size=self.model.image_size,
+            offload_video_to_cpu=offload_video_to_cpu,
+            async_loading_frames=async_loading_frames,
+            compute_device=compute_device,
+            transforms=self._transforms,
+        )
+        inference_state = {}
+        inference_state["res_path"] = res_path
+        inference_state["video_path"] = video_path
+        inference_state["res_track"] = np.zeros((0,4))
+        inference_state["resized_image_size"] = resized_image_size
+        inference_state["model_image_size"] = self.model.image_size
+        inference_state["padding"] = padding
+        inference_state["images"] = images
+        inference_state["num_frames"] = len(images)
+        inference_state["parent_ids"] = {}
+        # whether to offload the video frames to CPU memory
+        # turning on this option saves the GPU memory with only a very small overhead
+        inference_state["offload_video_to_cpu"] = offload_video_to_cpu
+        # whether to offload the inference state to CPU memory
+        # turning on this option saves the GPU memory at the cost of a lower tracking fps
+        # (e.g. in a test case of 768x768 model, fps dropped from 27 to 24 when tracking one object
+        # and from 24 to 21 when tracking two objects)
+        inference_state["offload_state_to_cpu"] = offload_state_to_cpu
+        # the original video height and width, used for resizing final output scores
+        inference_state["video_height"] = video_height
+        inference_state["video_width"] = video_width
+        inference_state["device"] = compute_device
+        if offload_state_to_cpu:
+            inference_state["storage_device"] = torch.device("cpu")
+        else:
+            inference_state["storage_device"] = compute_device
+        # inputs on each frame
+        inference_state["point_inputs_per_obj"] = {}
+        inference_state["mask_inputs_per_obj"] = {}
+        # visual features on a small number of recently visited frames for quick interactions
+        inference_state["cached_features"] = {}
+        # values that don't change across frames (so we only need to hold one copy of them)
+        inference_state["constants"] = {}
+        # mapping between client-side object id and model-side object index
+        inference_state["obj_ids"] = None
+        # Slice (view) of each object tracking results, sharing the same memory with "output_dict"
+        inference_state["output_dict_per_obj"] = {}
+        # A temporary storage to hold new outputs when user interact with a frame
+        # to add clicks or mask (it's merged into "output_dict" before propagation starts)
+        inference_state["temp_output_dict_per_obj"] = {}
+        # Frames that already holds consolidated outputs from click or mask inputs
+        # (we directly use their consolidated outputs during tracking)
+        # metadata for each tracking frame (e.g. which direction it's tracked)
+        inference_state["frames_tracked_per_obj"] = {}
+        inference_state["memory_dict"] = {}
+        # Warm up the visual backbone and cache the image feature on frame 0
+        self._get_image_feature(inference_state, frame_idx=0, batch_size=1)
+
+        return inference_state
+
+    def predict(self, video_path, res_path, offload_video_to_cpu=True, offload_state_to_cpu=False):
+        """
+        Predict and track cells throughout a video.
+        
+        Args:
+            video_path: Path to the video file
+            offload_video_to_cpu: Whether to offload video frames to CPU to save GPU memory
+            offload_state_to_cpu: Whether to offload inference state to CPU
+            
+        Returns:
+            Dictionary of tracking results with frame indices as keys
+        """
+        # Initialize the video state
+        inference_state = self.init_state(
+            video_path=video_path,
+            res_path=res_path,
+            offload_video_to_cpu=offload_video_to_cpu,
+            offload_state_to_cpu=offload_state_to_cpu
+        )
+        
+        # Generate points for the first frame
+        inference_state = self.generate_proportional_point_grid(inference_state)
+        
+        # Detect and track the detected cells through the video
+        tracking_results = self.track_cells(inference_state)
+        
+        self.save_tracking_results(inference_state, tracking_results)
+        
+        return tracking_results
+
+    def generate_proportional_point_grid(self, inference_state):
+        """
+        Generate a grid of (x, y) points with density proportional to the image size.
+        
+        Args:
+            inference_state: The video inference state
+        
+        Returns:
+            points: torch.Tensor of shape [N, 2] where each row is (x, y)
+            labels: torch.Tensor of shape [N] with all 1s (foreground)
+        """
+        H, W = inference_state["video_height"], inference_state["video_width"]
+        resized_H, resized_W = inference_state["resized_image_size"]
+        scale_factor_y = (resized_H / self.model.image_size)  # preserve relative density
+        scale_factor_x = (resized_W / self.model.image_size)  # preserve relative density
+
+        # Estimate number of points in each dimension
+        points_y = int(self.points_per_side * scale_factor_y) 
+        points_x = int(self.points_per_side * scale_factor_x)
+
+        # Avoid zero division or very few points
+        points_y = max(1, points_y)
+        points_x = max(1, points_x)
+
+        # Generate evenly spaced coordinates with proper offsets
+        # When only 1 point in a dimension, place it in the center
+        if points_y == 1:
+            ys = np.array([resized_H // 2], dtype=int)
+        else:
+            # Add offset to avoid placing points at the very edge
+            offset_y = resized_H / (2 * points_y)
+            ys = np.linspace(offset_y, resized_H - 1 - offset_y, points_y, dtype=int)
+            
+        if points_x == 1:
+            xs = np.array([resized_W // 2], dtype=int)
+        else:
+            # Add offset to avoid placing points at the very edge
+            offset_x = resized_W / (2 * points_x)
+            xs = np.linspace(offset_x, resized_W - 1 - offset_x, points_x, dtype=int)
+
+        # Images are center padded during training
+        xs += (self.model.image_size - inference_state["resized_image_size"][1]) // 2
+        ys += (self.model.image_size - inference_state["resized_image_size"][0]) // 2
+            
+        points = np.array(np.meshgrid(xs, ys)).T.reshape(-1, 2)[:,None]
+
+        # Convert points to tensor
+        points = torch.tensor(points, device=self.device, dtype=torch.float32)  # [N, 2]
+        
+        # Create corresponding labels tensor (all foreground)
+        labels = torch.ones((len(points), 1), dtype=torch.int, device=self.device)  # [N]
+        
+        # Save points and labels in inference_state for later reference
+        inference_state["point_inputs"] = {0: {"point_coords": points, "point_labels": labels}}
+
+        return inference_state
+
+    def track_cells(self, inference_state):
+        """
+        Track the detected cells throughout the video.
+        
+        Args:
+            inference_state: The video inference state
+            
+        Returns:
+            Dictionary of tracking results with frame indices as keys
+        """
+        tracking_results = []
+        
+        # Start propagation through the video
+        for frame_idx, inference_state, track_mask in self.propagate_in_video(inference_state):
+
+            tracking_results.append(track_mask)
+
+            self.save_ctc(track_mask, frame_idx, inference_state)
+        
+        return tracking_results
+
+    @torch.inference_mode()
+    def propagate_in_video(
+        self,
+        inference_state,
+        start_frame_idx=0,
+        max_frame_num_to_track=None,
+    ):
+        """Propagate the input points across frames to track in the entire video."""
+        num_frames = inference_state["num_frames"]
+        
+        if max_frame_num_to_track is None:
+            # default: track all the frames in the video
+            max_frame_num_to_track = num_frames
+
+        end_frame_idx = min(
+            start_frame_idx + max_frame_num_to_track, num_frames - 1
+        )
+        processing_order = range(start_frame_idx, end_frame_idx + 1)
+
+        for frame_idx in tqdm(processing_order, desc="propagate in video"):     
+
+            if frame_idx == 0:
+                tracking_object_ids = None
+                batch_size = inference_state["point_inputs"][frame_idx]['point_coords'].shape[0]
+            else:
+                tracking_object_ids = inference_state["obj_ids"][frame_idx-1]
+                batch_size = len(tracking_object_ids)       
+
+            if batch_size == 0:
+                inference_state["obj_ids"][frame_idx] = torch.zeros(0, device=self.device, dtype=torch.int32)
+                inference_state["parent_ids"][frame_idx] = torch.zeros(0, device=self.device, dtype=torch.int32)
+                continue
+
+            # Retrieve image features (only need to compute once for all objects)
+            (
+                _,
+                _,
+                current_vision_feats,
+                current_vision_pos_embeds,
+                feat_sizes,
+            ) = self._get_image_feature(inference_state, frame_idx, batch_size)
+            
+            # Run the core tracking step
+            current_out, sam_outputs, high_res_features, pix_feat = self.model._track_step(
+                is_init_cond_frame=frame_idx == 0,
+                current_vision_feats=current_vision_feats,
+                current_vision_pos_embeds=current_vision_pos_embeds,
+                feat_sizes=feat_sizes,
+                point_inputs=inference_state["point_inputs"].get(frame_idx, None),
+                mask_inputs=None,
+                num_frames=inference_state["num_frames"],
+                prev_sam_mask_logits=None,
+                tracking_object_ids=tracking_object_ids,
+                memory_dict=inference_state["memory_dict"],
+            )
+
+
+            # update cell tracks
+            inference_state, track_mask = self.update_cell_tracks(inference_state, frame_idx, sam_outputs, current_out, tracking_object_ids)
+
+            yield frame_idx, inference_state, track_mask
+
+    @torch.inference_mode()
+    def _get_image_feature(self, inference_state, frame_idx, batch_size):
+        """Compute the image features on a given frame."""
+        # Look up in the cache first
+        image, backbone_out = inference_state["cached_features"].get(
+            frame_idx, (None, None)
+        )
+        if backbone_out is None:
+            # Cache miss -- we will run inference on a single image
+            device = inference_state["device"]
+            image = inference_state["images"][frame_idx].to(device).float().unsqueeze(0)
+            # Clone the image to avoid inference mode tensor issues
+            image = image.clone()
+            backbone_out = self.model.forward_image(image)
+            # Cache the most recent frame's feature (for repeated interactions with
+            # a frame; we can use an LRU cache for more frames in the future).
+            inference_state["cached_features"] = {frame_idx: (image, backbone_out)}
+
+        # expand the features to have the same dimension as the number of objects
+        expanded_image = image.expand(batch_size, -1, -1, -1)
+        expanded_backbone_out = {
+            "backbone_fpn": backbone_out["backbone_fpn"].copy(),
+            "vision_pos_enc": backbone_out["vision_pos_enc"].copy(),
+        }
+        for i, feat in enumerate(expanded_backbone_out["backbone_fpn"]):
+            expanded_backbone_out["backbone_fpn"][i] = feat.expand(
+                batch_size, -1, -1, -1
+            )
+        for i, pos in enumerate(expanded_backbone_out["vision_pos_enc"]):
+            pos = pos.expand(batch_size, -1, -1, -1)
+            expanded_backbone_out["vision_pos_enc"][i] = pos
+
+        features = self.model._prepare_backbone_features(expanded_backbone_out)
+        features = (expanded_image,) + features
+        return features
+
+    def update_cell_tracks(self, inference_state, frame_idx, sam_outputs, current_out, tracking_object_ids):
+        """Update the cell tracks based on the current output and SAM outputs."""
+        obj_ids = tracking_object_ids
+        
+
+        # Unpack SAM outputs
+        (
+            ious,
+            low_res_masks,
+            high_res_masks,
+            obj_ptr,
+            object_score_logits_dict,
+            div_score_logits,
+            is_dividing,
+        ) = sam_outputs
+
+        keep_tokens = (
+            object_score_logits_dict["post_div"][:,0] > self.obj_score_thresh
+            ) * (
+                ious[:,0] > self.pred_iou_thresh
+            ) * (
+                high_res_masks > self.mask_threshold
+            ).sum((1,2,3)) > 0
+
+        
+        # Serialize predictions and store in MaskData
+        data = MaskData(
+            masks=high_res_masks[keep_tokens].flatten(0, 1),
+            iou_preds=ious[keep_tokens].flatten(0, 1),
+            low_res_masks=low_res_masks[keep_tokens].flatten(0, 1),
+            obj_scores=object_score_logits_dict["post_div"][keep_tokens].flatten(0,1),
+            obj_ptr=obj_ptr[keep_tokens]
+        )
+
+        data["boxes"] = batched_mask_to_box(data["masks"] > self.mask_threshold)
+        
+        keep_by_nms = batched_nms(
+            data["boxes"].float(),
+            data["iou_preds"],
+            torch.zeros_like(data["boxes"][:, 0]),  # categories
+            iou_threshold=self.box_nms_thresh,
+        ).sort()[0]
+
+        data.filter(keep_by_nms)
+
+        removed_indices = torch.nonzero(keep_tokens)[~torch.isin(torch.arange(keep_tokens.sum(), device=keep_tokens.device), keep_by_nms)]
+        keep_tokens[removed_indices] = False
+
+        if obj_ids is None: # only in first frame
+
+
+            num_cells = data["masks"].shape[0]
+            obj_ids = torch.arange(num_cells) + 1
+            prev_obj_ids = obj_ids.clone()
+            inference_state["obj_ids"] = {frame_idx: obj_ids}
+            inference_state["max_obj_id"] = max(obj_ids)
+            mother_ids = []
+            daughter_ids_list = []
+            parent_ids = torch.zeros(len(obj_ids), device=self.device, dtype=torch.int32)
+            inference_state["parent_ids"][frame_idx] = parent_ids
+        else:
+
+            # Get all potential mother cells before NMS
+            mother_ids = obj_ids[is_dividing]
+            daughter_ids = torch.arange(inference_state["max_obj_id"]+1, inference_state["max_obj_id"]+1+len(mother_ids)*2, device=self.device)
+            daughter_ids_list = daughter_ids.new_zeros((len(obj_ids),2))
+            daughter_ids_list[is_dividing] = daughter_ids.reshape(-1,2)
+
+            prev_obj_ids = obj_ids.clone()
+            
+            # Update obj_ids to include all potential daughters, even if they might be removed by NMS
+            obj_ids = torch.cat([obj_ids[~is_dividing], daughter_ids])
+            
+            # Now filter based on NMS results
+            obj_ids = obj_ids[keep_tokens]
+
+            parent_ids = torch.zeros(len(obj_ids), device=self.device, dtype=torch.int32)
+
+            # Update parent IDs for daughters that survived NMS
+            for mother_id, pair_daughter_ids in zip(mother_ids, daughter_ids.reshape(-1,2)):
+                if pair_daughter_ids[0] in obj_ids and pair_daughter_ids[1] in obj_ids:
+                    mask0 = obj_ids == pair_daughter_ids[0]
+                    mask1 = obj_ids == pair_daughter_ids[1]
+                    parent_ids[mask0] = mother_id
+                    parent_ids[mask1] = mother_id
+                else:
+                    # if one of the daughter cells is not in the final_obj_ids due to nms, then the other daughter cell must be the mother cell
+                    dau_id = pair_daughter_ids[0] if pair_daughter_ids[0] in obj_ids else pair_daughter_ids[1]
+                    obj_ids[obj_ids == dau_id] = mother_id
+                    mother_ids = mother_ids[mother_ids != mother_id]
+                    daughter_ids_list = daughter_ids_list.clone()
+                    daughter_ids_list[torch.isin(daughter_ids_list, pair_daughter_ids)] = 0
+
+            inference_state["obj_ids"][frame_idx] = obj_ids
+            inference_state["max_obj_id"] = max(obj_ids.tolist() + [inference_state["max_obj_id"]])
+            inference_state["parent_ids"][frame_idx] = parent_ids
+
+        if data["masks"].shape[0] == 0: 
+            track_mask = np.zeros((inference_state["video_height"], inference_state["video_width"]), dtype=np.uint16)
+            return inference_state, track_mask
+
+
+        current_out["pred_masks_high_res"] = data["masks"]
+        current_out["pred_object_score_logits"] = data["obj_scores"]
+        current_out["obj_ptr"] = data["obj_ptr"]
+
+        assert current_out["pred_masks_high_res"].shape[0] == len(obj_ids)
+
+        # Retrieve image features (only need to compute once for all objects)
+        (
+            _,
+            _,
+            current_vision_feats,
+            current_vision_pos_embeds,
+            feat_sizes,
+        ) = self._get_image_feature(inference_state, frame_idx, current_out["pred_masks_high_res"].shape[0])
+                        
+        inference_state["memory_dict"] = self.model._update_memory_features(
+            current_vision_feats,
+            feat_sizes,
+            inference_state["point_inputs"].get(frame_idx, None),
+            run_mem_encoder=True,
+            current_out=current_out,
+            memory_dict=inference_state["memory_dict"],
+            tracking_object_ids=obj_ids,
+            frame_idx=frame_idx,
+            mother_ids=mother_ids,
+            prev_tracking_object_ids=prev_obj_ids,
+            daughter_ids_list=daughter_ids_list,
+        )
+
+        track_mask = self.postprocess_mask(data["masks"], inference_state)
+
+        # Get the maximum value and index across all masks at each pixel position
+        max_values = np.max(track_mask, axis=0)  # returns max values
+        arg_max = np.argmax(track_mask, axis=0)  # returns indices
+        
+        # Create a mask filled with zeros (background)
+        track_mask = np.zeros_like(arg_max)
+        
+        # For pixels above threshold, assign the corresponding object ID
+        valid_pixels = max_values > self.mask_threshold
+        track_mask[valid_pixels] = obj_ids[arg_max[valid_pixels]]
+
+        return inference_state, track_mask
+    
+    def postprocess_mask(self, masks, inference_state):
+        pad_left, pad_right, pad_top, pad_bottom = inference_state["padding"]
+
+        pad_right = inference_state["model_image_size"] - pad_right
+        pad_bottom = inference_state["model_image_size"] - pad_bottom
+
+        masks = masks[:,pad_top:pad_bottom,pad_left:pad_right]
+        masks = masks.permute(1,2,0).cpu().numpy()
+        masks = cv2.resize(masks, (inference_state["video_width"], inference_state["video_height"]))
+        if masks.ndim == 2:
+            masks = masks[None,...]
+        else:
+            masks = masks.transpose(2,0,1)
+
+        return masks
+
+
+    def save_ctc(self, track_mask, frame_idx, inference_state):
+
+        res_track = inference_state["res_track"]
+        res_path = inference_state["res_path"]
+        parent_ids = inference_state["parent_ids"][frame_idx]
+
+        cell_ids = np.unique(track_mask)
+        cell_ids = cell_ids[cell_ids != 0]
+
+        if len(cell_ids) > 0:
+            assert max(cell_ids) < 65536, "cell_id must be less than 65536"
+
+        cv2.imwrite(str(res_path / f'mask_{frame_idx:03d}.tif'), track_mask.astype(np.uint16))
+
+        for cell_id, parent_id in zip(cell_ids, parent_ids):
+            if cell_id not in res_track[:,0]:
+                res_track = np.concatenate([res_track, np.array([[cell_id, frame_idx, frame_idx, parent_id]])], axis=0)
+            else:
+                assert res_track[res_track[:,0] == cell_id,2] == frame_idx-1, "cell_id must be continuous"
+                res_track[res_track[:,0] == cell_id,2] = frame_idx
+
+        np.savetxt(res_path / 'res_track.txt',res_track,fmt='%d')
+
+        inference_state["res_track"] = res_track
+
+    def save_tracking_results(self, inference_state, tracking_results, alpha=0.3):
+        res_track = inference_state["res_track"]
+        res_path = inference_state["res_path"]
+
+        num_colors = inference_state["max_obj_id"] + 1  # Add 1 to account for 0-based indexing
+        colors = np.random.randint(0, 255, (num_colors, 3))
+        color_stack = np.zeros((len(tracking_results), inference_state["video_height"], 
+                              inference_state["video_width"], 3), dtype=np.uint8)
+
+        for frame_idx, track_mask in enumerate(tracking_results):
+            img = cv2.imread(inference_state["video_path"] + f'/t{frame_idx:03d}.tif')
+
+            # Create a colored overlay image
+            overlay = np.zeros_like(img)
+            
+            cell_ids = np.unique(track_mask)
+            cell_ids = cell_ids[cell_ids != 0]  # Exclude background (0)
+            
+            # Add colored masks for each cell
+            for cell_id in cell_ids:
+                mask = track_mask == cell_id
+                overlay[mask] = colors[cell_id]
+            
+            # Blend original image with colored overlay
+            color_stack[frame_idx] = cv2.addWeighted(img, 1-alpha, overlay, alpha, 0)
+
+            for cell_id in cell_ids:
+                mask = track_mask == cell_id
+                y_coords, x_coords = np.where(mask)
+                if len(y_coords) == 0:
+                    continue
+                
+                centroid_y = int(np.mean(y_coords))
+                centroid_x = int(np.mean(x_coords))
+
+                cv2.putText(color_stack[frame_idx], 
+                          str(cell_id),
+                          (centroid_x-5, centroid_y+3),
+                          cv2.FONT_HERSHEY_SIMPLEX,
+                          0.5,  # Font scale
+                          (255, 255, 255),  # black color
+                          1,    # Line thickness
+                          cv2.LINE_AA)
+                
+            parent_ids = inference_state["parent_ids"][frame_idx].cpu().numpy()
+            parent_ids_unique = np.unique(parent_ids)
+            parent_ids_unique = parent_ids_unique[parent_ids_unique != 0]
+
+            for parent_id in parent_ids_unique:
+                dau_cell_ids = inference_state["obj_ids"][frame_idx][parent_ids == parent_id]
+
+                # Draw line between daughter cells
+                if len(dau_cell_ids) == 2:
+                    # Get centroids of both daughter cells
+                    mask1 = track_mask == dau_cell_ids[0]
+                    y1, x1 = np.where(mask1)
+                    if len(y1) > 0:
+                        centroid1_y = int(np.mean(y1))
+                        centroid1_x = int(np.mean(x1))
+
+                        mask2 = track_mask == dau_cell_ids[1] 
+                        y2, x2 = np.where(mask2)
+                        if len(y2) > 0:
+                            centroid2_y = int(np.mean(y2))
+                            centroid2_x = int(np.mean(x2))
+
+                            # Draw line connecting centroids
+                            cv2.line(color_stack[frame_idx],
+                                    (centroid1_x, centroid1_y),
+                                    (centroid2_x, centroid2_y),
+                                    (0, 0, 0),  # Black color
+                                    1)  # Line thickness
+
+            # Add frame number to top of frame
+            cv2.putText(color_stack[frame_idx],
+                        f"{frame_idx:03}",
+                        (5, 15), # Position in top-left
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        0.5,  # Font scale 
+                        (0, 0, 0),  # Black color
+                        1,    # Line thickness
+                        cv2.LINE_AA)
+
+        # Save as video
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+        out = cv2.VideoWriter(str(res_path / 'pred_video.mp4'), 
+                            fourcc, 10.0, # 10 fps
+                            (inference_state["video_width"], inference_state["video_height"]))
+        
+        for frame in color_stack:
+            out.write(cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
+            
+        out.release()
+
+
+
+            
+

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -772,8 +772,12 @@ class SAM2AutomaticCellTracker:
 
         res_path = inference_state["res_path"]
 
-        cell_ids = np.unique(track_mask)
-        cell_ids = cell_ids[cell_ids != 0]
+        cell_ids_track_mask = np.unique(track_mask)
+        cell_ids_track_mask = cell_ids_track_mask[cell_ids_track_mask != 0]
+
+        cell_ids = inference_state["obj_ids"][frame_idx].cpu().numpy()
+
+        assert sorted(cell_ids_track_mask) == sorted(cell_ids), "cell_ids_track_mask and cell_ids must be the same"
 
         if len(cell_ids) > 0:
             assert max(cell_ids) < 65536, "cell_id must be less than 65536"

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -393,7 +393,7 @@ class SAM2AutomaticCellTracker:
                         memory_dict=inference_state["memory_dict"],
                     )
 
-                    inference_state, detected_mask = self.update_cell_tracks(inference_state, frame_idx, sam_outputs, current_out, tracking_object_ids, heatmap_input=True)
+                    inference_state, detected_mask = self.update_cell_tracks(inference_state, frame_idx, sam_outputs, current_out, heatmap_input=True)
 
                     if detected_mask.sum() > 0:
                         detected_cells = np.unique(detected_mask)
@@ -516,7 +516,7 @@ class SAM2AutomaticCellTracker:
         features = (expanded_image,) + features
         return features
 
-    def update_cell_tracks(self, inference_state, frame_idx, sam_outputs, current_out, tracking_object_ids, heatmap_input=False):
+    def update_cell_tracks(self, inference_state, frame_idx, sam_outputs, current_out, tracking_object_ids=None, heatmap_input=False):
         """Update the cell tracks based on the current output and SAM outputs."""
         obj_ids = tracking_object_ids
         

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -32,7 +32,7 @@ class SAM2AutomaticCellTracker:
         div_obj_score_thresh: float = 0,
         stability_score_thresh: float = 0,
         stability_score_offset: float = 1.0,
-        box_nms_thresh: float = 0.7,
+        box_nms_thresh: float = 0.5,
         max_hole_area: int = 0,
         max_sprinkle_area: int = 0,
         mask_threshold: float = 0.0,

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -424,7 +424,7 @@ class SAM2AutomaticCellTracker:
                             cells_to_remove = set()  # Track which cells to remove
                             
                             for idx in sorted_indices:
-                                if max_ious[idx] > 0.05:  # IoU threshold
+                                if max_ious[idx] > 0:  # If cell has positive object score, it is assumed to be match if there is any overlap
                                     detected_cell_id = int(detected_cells[idx])
                                     lost_idx = lost_cell_indices[idx]
                                     lost_cell_id = int(lost_obj_ids[lost_idx])
@@ -472,7 +472,7 @@ class SAM2AutomaticCellTracker:
                                         best_iou = iou
                                         best_track_id = track_id
                                 
-                                if best_iou > 0.3:  # If there's significant overlap
+                                if best_iou > 0.05:  # If there's any overlap, assume it's the same cell
                                     # Update the detected mask to use the best matching track ID
                                     detected_mask[detected_mask_binary] = best_track_id
                                     inference_state["memory_dict"][best_track_id]['mask_mem_features'][-1] = inference_state["memory_dict"][detected_cell_id]['mask_mem_features'][0]

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -128,6 +128,7 @@ class SAM2AutomaticCellTracker:
         offload_video_to_cpu=False,
         offload_state_to_cpu=False,
         async_loading_frames=False,
+        max_frame_num_to_track=None,
     ):
         """Initialize an inference state."""
         compute_device = self.model.device  # device of the model
@@ -149,6 +150,7 @@ class SAM2AutomaticCellTracker:
         inference_state["images"] = images
         inference_state["num_frames"] = len(images)
         inference_state["parent_ids"] = {}
+        inference_state["max_frame_num_to_track"] = max_frame_num_to_track
         # whether to offload the video frames to CPU memory
         # turning on this option saves the GPU memory with only a very small overhead
         inference_state["offload_video_to_cpu"] = offload_video_to_cpu
@@ -186,7 +188,7 @@ class SAM2AutomaticCellTracker:
 
         return inference_state
 
-    def predict(self, video_path, res_path, offload_video_to_cpu=True, offload_state_to_cpu=False):
+    def predict(self, video_path, res_path, offload_video_to_cpu=True, offload_state_to_cpu=False, max_frame_num_to_track=None):
         """
         Predict and track cells throughout a video.
         
@@ -203,7 +205,8 @@ class SAM2AutomaticCellTracker:
             video_path=video_path,
             res_path=res_path,
             offload_video_to_cpu=offload_video_to_cpu,
-            offload_state_to_cpu=offload_state_to_cpu
+            offload_state_to_cpu=offload_state_to_cpu,
+            max_frame_num_to_track=max_frame_num_to_track
         )
         
         if not self.use_heatmap:
@@ -304,10 +307,10 @@ class SAM2AutomaticCellTracker:
         self,
         inference_state,
         start_frame_idx=0,
-        max_frame_num_to_track=None,
     ):
         """Propagate the input points across frames to track in the entire video."""
         num_frames = inference_state["num_frames"]
+        max_frame_num_to_track = inference_state["max_frame_num_to_track"]
         
         if max_frame_num_to_track is None:
             # default: track all the frames in the video

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -421,6 +421,7 @@ class SAM2AutomaticCellTracker:
                             # Process each detected cell in order of IoU
                             sorted_indices = np.argsort(-max_ious)  # Sort by descending IoU
                             processed_lost_cells = set()
+                            cells_to_remove = set()  # Track which cells to remove
                             
                             for idx in sorted_indices:
                                 if max_ious[idx] > 0.05:  # IoU threshold
@@ -439,10 +440,13 @@ class SAM2AutomaticCellTracker:
                                         inference_state["memory_dict"][lost_cell_id]['frame_idx'].append(frame_idx)
                                         inference_state["obj_ids"][frame_idx][inference_state["obj_ids"][frame_idx] == detected_cell_id] = lost_cell_id
                                         
-                                        detected_cells = detected_cells[detected_cells != detected_cell_id]
+                                        cells_to_remove.add(detected_cell_id)  # Mark for removal
                                         processed_lost_cells.add(lost_cell_id)
                                         
                                         del inference_state["memory_dict"][detected_cell_id]
+
+                            # Remove the cells after processing all matches
+                            detected_cells = detected_cells[~np.isin(detected_cells, list(cells_to_remove))]
 
                         # Handle remaining detected cells
                         for detected_cell_id in detected_cells:

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -318,173 +318,175 @@ class SAM2AutomaticCellTracker:
             if batch_size == 0:
                 inference_state["obj_ids"][frame_idx] = torch.zeros(0, device=self.device, dtype=torch.int32)
                 inference_state["parent_ids"][frame_idx] = torch.zeros(0, device=self.device, dtype=torch.int32)
-                continue
+                track_mask = np.zeros((inference_state["video_height"], inference_state["video_width"]), dtype=np.uint16)
+                yield frame_idx, inference_state, track_mask
 
-            # Retrieve image features (only need to compute once for all objects)
-            (
-                _,
-                _,
-                current_vision_feats,
-                current_vision_pos_embeds,
-                feat_sizes,
-            ) = self._get_image_feature(inference_state, frame_idx, batch_size)
-            
-            # Run the core tracking step
-            current_out, sam_outputs, high_res_features, pix_feat = self.model._track_step(
-                is_init_cond_frame=is_init_cond_frame,
-                current_vision_feats=current_vision_feats,
-                current_vision_pos_embeds=current_vision_pos_embeds,
-                feat_sizes=feat_sizes,
-                point_inputs=inference_state["point_inputs"].get(frame_idx, None),
-                mask_inputs=None,
-                num_frames=inference_state["num_frames"],
-                prev_sam_mask_logits=None,
-                tracking_object_ids=tracking_object_ids,
-                memory_dict=inference_state["memory_dict"],
-            )
+            else:
+                # Retrieve image features (only need to compute once for all objects)
+                (
+                    _,
+                    _,
+                    current_vision_feats,
+                    current_vision_pos_embeds,
+                    feat_sizes,
+                ) = self._get_image_feature(inference_state, frame_idx, batch_size)
+                
+                # Run the core tracking step
+                current_out, sam_outputs, high_res_features, pix_feat = self.model._track_step(
+                    is_init_cond_frame=is_init_cond_frame,
+                    current_vision_feats=current_vision_feats,
+                    current_vision_pos_embeds=current_vision_pos_embeds,
+                    feat_sizes=feat_sizes,
+                    point_inputs=inference_state["point_inputs"].get(frame_idx, None),
+                    mask_inputs=None,
+                    num_frames=inference_state["num_frames"],
+                    prev_sam_mask_logits=None,
+                    tracking_object_ids=tracking_object_ids,
+                    memory_dict=inference_state["memory_dict"],
+                )
 
 
-            # update cell tracks
-            inference_state, track_mask = self.update_cell_tracks(inference_state, frame_idx, sam_outputs, current_out, tracking_object_ids)
+                # update cell tracks
+                inference_state, track_mask = self.update_cell_tracks(inference_state, frame_idx, sam_outputs, current_out, tracking_object_ids)
 
-            if not self.segment and frame_idx > 0 and self.use_heatmap:
-                input_points, point_labels = self.get_input_points_from_heatmap(inference_state, frame_idx)
-                input_points_copy = input_points.clone()
+                if not self.segment and frame_idx > 0 and self.use_heatmap:
+                    input_points, point_labels = self.get_input_points_from_heatmap(inference_state, frame_idx)
+                    input_points_copy = input_points.clone()
 
-                pad_left, pad_right, pad_top, pad_bottom = inference_state["padding"]
-                input_points[:,0,0] -= pad_left
-                input_points[:,0,1] -= pad_top
+                    pad_left, pad_right, pad_top, pad_bottom = inference_state["padding"]
+                    input_points[:,0,0] -= pad_left
+                    input_points[:,0,1] -= pad_top
 
-                input_points[:,0,0] = (input_points[:,0,0] * (inference_state["video_width"] / inference_state["resized_image_size"][1]))
-                input_points[:,0,1] = (input_points[:,0,1] * (inference_state["video_height"] / inference_state["resized_image_size"][0]))
+                    input_points[:,0,0] = (input_points[:,0,0] * (inference_state["video_width"] / inference_state["resized_image_size"][1]))
+                    input_points[:,0,1] = (input_points[:,0,1] * (inference_state["video_height"] / inference_state["resized_image_size"][0]))
 
-                # Convert to numpy and int
-                input_points_np = input_points.cpu().numpy().astype(np.int32)
-                track_cell_ids = track_mask[input_points_np[:,0,1], input_points_np[:,0,0]]
+                    # Convert to numpy and int
+                    input_points_np = input_points.cpu().numpy().astype(np.int32)
+                    track_cell_ids = track_mask[input_points_np[:,0,1], input_points_np[:,0,0]]
 
-                # Find indices where track_cell_ids is 0 (background)
-                background_point_indices = np.where(track_cell_ids == 0)[0]
+                    # Find indices where track_cell_ids is 0 (background)
+                    background_point_indices = np.where(track_cell_ids == 0)[0]
 
-                if len(background_point_indices) > 0:
-                    input_points = input_points_copy[background_point_indices]
-                    point_labels = point_labels[background_point_indices]
+                    if len(background_point_indices) > 0:
+                        input_points = input_points_copy[background_point_indices]
+                        point_labels = point_labels[background_point_indices]
 
-                    inference_state["point_inputs"][frame_idx] = {"point_coords": input_points, "point_labels": point_labels}
-                    batch_size = input_points.shape[0]
+                        inference_state["point_inputs"][frame_idx] = {"point_coords": input_points, "point_labels": point_labels}
+                        batch_size = input_points.shape[0]
 
-                    # Retrieve image features (only need to compute once for all objects)
-                    (
-                        _,
-                        _,
-                        current_vision_feats,
-                        current_vision_pos_embeds,
-                        feat_sizes,
-                    ) = self._get_image_feature(inference_state, frame_idx, batch_size)
-                    
-                    # Run the core tracking step
-                    current_out, sam_outputs, high_res_features, pix_feat = self.model._track_step(
-                        is_init_cond_frame=True,
-                        current_vision_feats=current_vision_feats,
-                        current_vision_pos_embeds=current_vision_pos_embeds,
-                        feat_sizes=feat_sizes,
-                        point_inputs=inference_state["point_inputs"].get(frame_idx, None),
-                        mask_inputs=None,
-                        num_frames=inference_state["num_frames"],
-                        prev_sam_mask_logits=None,
-                        tracking_object_ids=None,
-                        memory_dict=inference_state["memory_dict"],
-                    )
-
-                    inference_state, detected_mask = self.update_cell_tracks(inference_state, frame_idx, sam_outputs, current_out, heatmap_input=True)
-
-                    if detected_mask.sum() > 0:
-                        detected_cells = np.unique(detected_mask)
-                        detected_cells = detected_cells[detected_cells != 0]
+                        # Retrieve image features (only need to compute once for all objects)
+                        (
+                            _,
+                            _,
+                            current_vision_feats,
+                            current_vision_pos_embeds,
+                            feat_sizes,
+                        ) = self._get_image_feature(inference_state, frame_idx, batch_size)
                         
-                        if len(inference_state["lost_obj_ids"][frame_idx]) > 0:
-                            lost_obj_ids = inference_state["lost_obj_ids"][frame_idx]
-                            lost_high_res_masks = inference_state["lost_high_res_masks"][frame_idx]
+                        # Run the core tracking step
+                        current_out, sam_outputs, high_res_features, pix_feat = self.model._track_step(
+                            is_init_cond_frame=True,
+                            current_vision_feats=current_vision_feats,
+                            current_vision_pos_embeds=current_vision_pos_embeds,
+                            feat_sizes=feat_sizes,
+                            point_inputs=inference_state["point_inputs"].get(frame_idx, None),
+                            mask_inputs=None,
+                            num_frames=inference_state["num_frames"],
+                            prev_sam_mask_logits=None,
+                            tracking_object_ids=None,
+                            memory_dict=inference_state["memory_dict"],
+                        )
 
-                            # Calculate IoU between each detected cell and lost cell
-                            ious = np.zeros((len(detected_cells), len(lost_obj_ids)))
-                            for i, detected_id in enumerate(detected_cells):
-                                detected_mask_binary = detected_mask == detected_id
-                                for j, lost_id in enumerate(lost_obj_ids):
-                                    intersection = np.logical_and(detected_mask_binary, lost_high_res_masks[j]).sum()
-                                    union = np.logical_or(detected_mask_binary, lost_high_res_masks[j]).sum()
-                                    ious[i,j] = intersection / union if union > 0 else 0
+                        inference_state, detected_mask = self.update_cell_tracks(inference_state, frame_idx, sam_outputs, current_out, heatmap_input=True)
 
-                            # Find the lost cell with the highest IoU for each detected cell
-                            max_ious = np.max(ious, axis=1)
-                            lost_cell_indices = np.argmax(ious, axis=1)
+                        if detected_mask.sum() > 0:
+                            detected_cells = np.unique(detected_mask)
+                            detected_cells = detected_cells[detected_cells != 0]
                             
-                            # Process each detected cell in order of IoU
-                            sorted_indices = np.argsort(-max_ious)  # Sort by descending IoU
-                            processed_lost_cells = set()
-                            cells_to_remove = set()  # Track which cells to remove
-                            
-                            for idx in sorted_indices:
-                                if max_ious[idx] > 0:  # If cell has positive object score, it is assumed to be match if there is any overlap
-                                    detected_cell_id = int(detected_cells[idx])
-                                    lost_idx = lost_cell_indices[idx]
-                                    lost_cell_id = int(lost_obj_ids[lost_idx])
+                            if len(inference_state["lost_obj_ids"][frame_idx]) > 0:
+                                lost_obj_ids = inference_state["lost_obj_ids"][frame_idx]
+                                lost_high_res_masks = inference_state["lost_high_res_masks"][frame_idx]
+
+                                # Calculate IoU between each detected cell and lost cell
+                                ious = np.zeros((len(detected_cells), len(lost_obj_ids)))
+                                for i, detected_id in enumerate(detected_cells):
+                                    detected_mask_binary = detected_mask == detected_id
+                                    for j, lost_id in enumerate(lost_obj_ids):
+                                        intersection = np.logical_and(detected_mask_binary, lost_high_res_masks[j]).sum()
+                                        union = np.logical_or(detected_mask_binary, lost_high_res_masks[j]).sum()
+                                        ious[i,j] = intersection / union if union > 0 else 0
+
+                                # Find the lost cell with the highest IoU for each detected cell
+                                max_ious = np.max(ious, axis=1)
+                                lost_cell_indices = np.argmax(ious, axis=1)
+                                
+                                # Process each detected cell in order of IoU
+                                sorted_indices = np.argsort(-max_ious)  # Sort by descending IoU
+                                processed_lost_cells = set()
+                                cells_to_remove = set()  # Track which cells to remove
+                                
+                                for idx in sorted_indices:
+                                    if max_ious[idx] > 0:  # If cell has positive object score, it is assumed to be match if there is any overlap
+                                        detected_cell_id = int(detected_cells[idx])
+                                        lost_idx = lost_cell_indices[idx]
+                                        lost_cell_id = int(lost_obj_ids[lost_idx])
+                                        
+                                        # Skip if this lost cell was already matched
+                                        if lost_cell_id in processed_lost_cells:
+                                            continue
+                                            
+                                        if frame_idx - 1 in inference_state["memory_dict"][lost_cell_id]['frame_idx']:
+                                            detected_mask[detected_mask == detected_cell_id] = lost_cell_id
+                                            inference_state["memory_dict"][lost_cell_id]['mask_mem_features'] = torch.cat((inference_state["memory_dict"][lost_cell_id]['mask_mem_features'], inference_state["memory_dict"][detected_cell_id]['mask_mem_features']), dim=0)
+                                            inference_state["memory_dict"][lost_cell_id]['obj_ptr'] = torch.cat((inference_state["memory_dict"][lost_cell_id]['obj_ptr'], inference_state["memory_dict"][detected_cell_id]['obj_ptr']), dim=0)
+                                            inference_state["memory_dict"][lost_cell_id]['frame_idx'].append(frame_idx)
+                                            inference_state["obj_ids"][frame_idx][inference_state["obj_ids"][frame_idx] == detected_cell_id] = lost_cell_id
+                                            
+                                            cells_to_remove.add(detected_cell_id)  # Mark for removal
+                                            processed_lost_cells.add(lost_cell_id)
+                                            
+                                            del inference_state["memory_dict"][detected_cell_id]
+
+                                # Remove the cells after processing all matches
+                                detected_cells = detected_cells[~np.isin(detected_cells, list(cells_to_remove))]
+
+                            # Handle remaining detected cells
+                            for detected_cell_id in detected_cells:
+                                # Get binary mask for current detected cell
+                                detected_mask_binary = detected_mask == detected_cell_id
+                                
+                                # Get all unique track IDs that overlap with this detected cell
+                                overlapping_track_ids = np.unique(track_mask[detected_mask_binary])
+                                overlapping_track_ids = overlapping_track_ids[overlapping_track_ids > 0]  # Remove background (0)
+                                
+                                if len(overlapping_track_ids) > 0:
+                                    # Calculate IoU with each overlapping track
+                                    best_iou = 0
+                                    best_track_id = None
                                     
-                                    # Skip if this lost cell was already matched
-                                    if lost_cell_id in processed_lost_cells:
-                                        continue
+                                    for track_id in overlapping_track_ids:
+                                        track_mask_binary = track_mask == track_id
+                                        intersection = np.logical_and(detected_mask_binary, track_mask_binary).sum()
+                                        union = np.logical_or(detected_mask_binary, track_mask_binary).sum()
+                                        iou = intersection / union if union > 0 else 0
                                         
-                                    if frame_idx - 1 in inference_state["memory_dict"][lost_cell_id]['frame_idx']:
-                                        detected_mask[detected_mask == detected_cell_id] = lost_cell_id
-                                        inference_state["memory_dict"][lost_cell_id]['mask_mem_features'] = torch.cat((inference_state["memory_dict"][lost_cell_id]['mask_mem_features'], inference_state["memory_dict"][detected_cell_id]['mask_mem_features']), dim=0)
-                                        inference_state["memory_dict"][lost_cell_id]['obj_ptr'] = torch.cat((inference_state["memory_dict"][lost_cell_id]['obj_ptr'], inference_state["memory_dict"][detected_cell_id]['obj_ptr']), dim=0)
-                                        inference_state["memory_dict"][lost_cell_id]['frame_idx'].append(frame_idx)
-                                        inference_state["obj_ids"][frame_idx][inference_state["obj_ids"][frame_idx] == detected_cell_id] = lost_cell_id
-                                        
-                                        cells_to_remove.add(detected_cell_id)  # Mark for removal
-                                        processed_lost_cells.add(lost_cell_id)
+                                        if iou > best_iou:
+                                            best_iou = iou
+                                            best_track_id = track_id
+                                    
+                                    if best_iou > 0.05:  # If there's any overlap, assume it's the same cell
+                                        # Update the detected mask to use the best matching track ID
+                                        detected_mask[detected_mask_binary] = best_track_id
+                                        inference_state["memory_dict"][best_track_id]['mask_mem_features'][-1] = inference_state["memory_dict"][detected_cell_id]['mask_mem_features'][0]
+                                        inference_state["memory_dict"][best_track_id]['obj_ptr'][-1] = inference_state["memory_dict"][detected_cell_id]['obj_ptr'][0]
+                                        inference_state["parent_ids"][frame_idx] = inference_state["parent_ids"][frame_idx][inference_state["obj_ids"][frame_idx] != detected_cell_id]
+                                        inference_state["obj_ids"][frame_idx] = inference_state["obj_ids"][frame_idx][inference_state["obj_ids"][frame_idx] != detected_cell_id]
                                         
                                         del inference_state["memory_dict"][detected_cell_id]
-
-                            # Remove the cells after processing all matches
-                            detected_cells = detected_cells[~np.isin(detected_cells, list(cells_to_remove))]
-
-                        # Handle remaining detected cells
-                        for detected_cell_id in detected_cells:
-                            # Get binary mask for current detected cell
-                            detected_mask_binary = detected_mask == detected_cell_id
-                            
-                            # Get all unique track IDs that overlap with this detected cell
-                            overlapping_track_ids = np.unique(track_mask[detected_mask_binary])
-                            overlapping_track_ids = overlapping_track_ids[overlapping_track_ids > 0]  # Remove background (0)
-                            
-                            if len(overlapping_track_ids) > 0:
-                                # Calculate IoU with each overlapping track
-                                best_iou = 0
-                                best_track_id = None
                                 
-                                for track_id in overlapping_track_ids:
-                                    track_mask_binary = track_mask == track_id
-                                    intersection = np.logical_and(detected_mask_binary, track_mask_binary).sum()
-                                    union = np.logical_or(detected_mask_binary, track_mask_binary).sum()
-                                    iou = intersection / union if union > 0 else 0
-                                    
-                                    if iou > best_iou:
-                                        best_iou = iou
-                                        best_track_id = track_id
-                                
-                                if best_iou > 0.05:  # If there's any overlap, assume it's the same cell
-                                    # Update the detected mask to use the best matching track ID
-                                    detected_mask[detected_mask_binary] = best_track_id
-                                    inference_state["memory_dict"][best_track_id]['mask_mem_features'][-1] = inference_state["memory_dict"][detected_cell_id]['mask_mem_features'][0]
-                                    inference_state["memory_dict"][best_track_id]['obj_ptr'][-1] = inference_state["memory_dict"][detected_cell_id]['obj_ptr'][0]
-                                    inference_state["parent_ids"][frame_idx] = inference_state["parent_ids"][frame_idx][inference_state["obj_ids"][frame_idx] != detected_cell_id]
-                                    inference_state["obj_ids"][frame_idx] = inference_state["obj_ids"][frame_idx][inference_state["obj_ids"][frame_idx] != detected_cell_id]
-                                    
-                                    del inference_state["memory_dict"][detected_cell_id]
-                            
-                        track_mask[(detected_mask > 0) * (track_mask == 0)] = detected_mask[(detected_mask > 0) * (track_mask == 0)]
+                            track_mask[(detected_mask > 0) * (track_mask == 0)] = detected_mask[(detected_mask > 0) * (track_mask == 0)]
 
-            yield frame_idx, inference_state, track_mask
+                yield frame_idx, inference_state, track_mask
 
     @torch.inference_mode()
     def _get_image_feature(self, inference_state, frame_idx, batch_size):

--- a/inference/cell_tracker.py
+++ b/inference/cell_tracker.py
@@ -640,7 +640,9 @@ class SAM2AutomaticCellTracker:
             lost_obj_ids = obj_ids[valid_next_frame_mask * (~keep_tokens)]
             inference_state["lost_obj_ids"][frame_idx] = lost_obj_ids
             if len(lost_obj_ids) > 0:
-                lost_high_res_masks = self.postprocess_mask(save_masks[valid_next_frame_mask * (~keep_tokens)].flatten(0,1), inference_state)
+                lost_high_res_masks = save_masks[valid_next_frame_mask * (~keep_tokens)].flatten(0,1)
+                lost_high_res_masks[:,(data["masks"] > self.mask_threshold).sum(0) > 0] = -torch.inf
+                lost_high_res_masks = self.postprocess_mask(lost_high_res_masks, inference_state)
                 inference_state["lost_high_res_masks"][frame_idx] = lost_high_res_masks > self.mask_threshold
 
             obj_ids = obj_ids[keep_tokens]

--- a/inference/inference_utils.py
+++ b/inference/inference_utils.py
@@ -66,7 +66,7 @@ def get_video_path() -> Path:
 
     return Path(path_result[0])
 
-def get_result_path(base_dir: Path, model_name: str, input_path: Path, dir_name: str, res_path: Path = None, idx: int = None) -> Path:
+def get_result_path(base_dir: Path, model_name: str, input_path: Path, dir_name: str, res_path: Path = None) -> Path:
     """Generate the result path based on input path structure.
     
     Args:
@@ -80,7 +80,7 @@ def get_result_path(base_dir: Path, model_name: str, input_path: Path, dir_name:
         Path: Result directory path
     """
     if res_path is not None:
-        return res_path / f'res_{idx}'
+        return Path(res_path) / dir_name
     
     # Start with common base path
     result_path = base_dir / 'sam2_logs' / model_name / 'results'

--- a/inference/inference_utils.py
+++ b/inference/inference_utils.py
@@ -1,33 +1,130 @@
 import numpy as np
 import torch
 import matplotlib.pyplot as plt
+import cv2
+from pathlib import Path
+import tkinter as tk
+from tkinter import filedialog
 
 def get_device():
-
-    # select the device for computation
+    """Get the device to use for computation."""
     if torch.cuda.is_available():
-        device = torch.device("cuda")
+        return torch.device("cuda")
     elif torch.backends.mps.is_available():
-        device = torch.device("mps")
+        return torch.device("mps")
     else:
-        device = torch.device("cpu")
-    print(f"using device: {device}")
+        return torch.device("cpu")
 
-    if device.type == "cuda":
-        # use bfloat16 for the entire notebook
-        torch.autocast("cuda", dtype=torch.bfloat16).__enter__()
-        # turn on tfloat32 for Ampere GPUs (https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices)
-        if torch.cuda.get_device_properties(0).major >= 8:
-            torch.backends.cuda.matmul.allow_tf32 = True
-            torch.backends.cudnn.allow_tf32 = True
-    elif device.type == "mps":
-        print(
-            "\nSupport for MPS devices is preliminary. SAM 2 is trained with CUDA and might "
-            "give numerically different outputs and sometimes degraded performance on MPS. "
-            "See e.g. https://github.com/pytorch/pytorch/issues/84936 for a discussion."
-        )
+def get_video_path() -> Path:
+    """Open a GUI dialog for selecting video file or image sequence directory.
+    
+    Returns:
+        Path: Selected path to video file or image directory
+    """
+    # Create and hide the root window
+    root = tk.Tk()
+    root.withdraw()
+    
+    # Ask user if they want to select a video or a folder of images
+    selection_window = tk.Toplevel(root)
+    selection_window.title("Select Input Type")
+    selection_window.geometry("300x150")
+    selection_window.resizable(False, False)
+    
+    selected_option = tk.StringVar(value="video")
+    
+    tk.Label(selection_window, text="Choose input type:").pack(pady=10)
+    tk.Radiobutton(selection_window, text="Video file", variable=selected_option, value="video").pack(anchor=tk.W, padx=20)
+    tk.Radiobutton(selection_window, text="Folder of images", variable=selected_option, value="images").pack(anchor=tk.W, padx=20)
+    
+    path_result = [None]  # Use list to store result from callback
+    
+    def on_confirm():
+        option = selected_option.get()
+        if option == "video":
+            path_result[0] = filedialog.askopenfilename(
+                title="Select a video file",
+                filetypes=[
+                    ("Video files", "*.mp4 *.avi *.mov *.mkv"),
+                    ("All files", "*.*")
+                ]
+            )
+        else:  # images
+            path_result[0] = filedialog.askdirectory(
+                title="Select folder containing image sequence"
+            )
+        selection_window.destroy()
+    
+    tk.Button(selection_window, text="Confirm", command=on_confirm).pack(pady=20)
+    
+    # Wait for the window to be closed
+    selection_window.wait_window()
+    
+    if not path_result[0]:
+        print("No input selected. Exiting...")
+        exit()
 
-    return device
+    return Path(path_result[0])
+
+def get_result_path(base_dir: Path, model_name: str, input_path: Path, dir_name: str, res_path: Path = None, idx: int = None) -> Path:
+    """Generate the result path based on input path structure.
+    
+    Args:
+        base_dir: Base directory (usually __file__.parents[1])
+        model_name: Name of the model being used
+        input_path: Input path being processed
+        dir_name: Name of directory being processed
+        res_path: Result path to save to
+
+    Returns:
+        Path: Result directory path
+    """
+    if res_path is not None:
+        return res_path / f'res_{idx}'
+    
+    # Start with common base path
+    result_path = base_dir / 'sam2_logs' / model_name / 'results'
+    
+    # Add split directory if in train/val/test
+    if 'test' in input_path.parts:
+        result_path = result_path / 'test'
+    elif 'train' in input_path.parts:
+        result_path = result_path / 'train'
+    elif 'val' in input_path.parts:
+        result_path = result_path / 'val'
+    
+    # Add CTC directory if in CTC dataset
+    if 'CTC' in input_path.parts:
+        result_path = result_path / 'CTC'
+    
+    # Add final directory name
+    return result_path / dir_name
+
+def has_tif_files(path):
+    """Check if the directory contains .tif files."""
+    path = Path(path)
+    return any(f.suffix.lower() == '.tif' for f in path.glob('*.[tT][iI][fF]'))
+
+def get_tif_directories(base_path):
+    """Get all directories containing .tif files."""
+    base_path = Path(base_path)
+    if not base_path.is_dir():
+        raise ValueError(f"{base_path} is not a directory")
+    
+    # If the base directory has .tif files, return just that
+    if has_tif_files(base_path):
+        return [base_path]
+    
+    # Otherwise, look for subdirectories with .tif files
+    tif_dirs = []
+    for subdir in base_path.iterdir():
+        if subdir.is_dir() and has_tif_files(subdir):
+            tif_dirs.append(subdir)
+    
+    if not tif_dirs:
+        raise ValueError(f"No directories containing .tif files found in {base_path}")
+    
+    return sorted(tif_dirs)
 
 def display_masks(image, masks):
 
@@ -51,7 +148,6 @@ def show_anns(anns, borders=True, mask_alpha=0.1):
         color_mask = np.concatenate([np.random.random(3), [mask_alpha]])
         img[m] = color_mask 
         if borders:
-            import cv2
             contours, _ = cv2.findContours(m.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE) 
             # Try to smooth contours
             contours = [cv2.approxPolyDP(contour, epsilon=0.01, closed=True) for contour in contours]

--- a/inference/track_cells.py
+++ b/inference/track_cells.py
@@ -48,7 +48,8 @@ def main(config_name):
         box_nms_thresh=0.7,
         min_mask_region_area=30,
         use_m2m=True,  # Use mask-to-mask refinement
-        segment=True,
+        segment=False,
+        use_heatmap=True,
     )
 
     video_path = 'C:/Users/17742/Documents/DeepLearning/datasets/moma/CTC/test/29'

--- a/inference/track_cells.py
+++ b/inference/track_cells.py
@@ -1,0 +1,117 @@
+# Third-party imports
+import cv2
+import hydra
+from hydra.core.global_hydra import GlobalHydra
+import tkinter as tk
+from tkinter import filedialog
+import sys
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+import matplotlib.patches as patches
+
+# Local imports
+from sam2.build_sam import build_sam2
+from cell_tracker import SAM2AutomaticCellTracker
+from inference_utils import get_device
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+model_name = "SAM2-tracking-LoRA"  
+sam2_checkpoint = f"sam2_logs/{model_name}/checkpoints/checkpoint.pt"
+
+config_path = f"../sam2_logs/{model_name}"
+config_name = "config_resolved"
+
+# Clear any existing Hydra instance
+if GlobalHydra().is_initialized():
+    GlobalHydra.instance().clear()
+
+# global initialization
+hydra.initialize(version_base=None, config_path=config_path)
+
+device = get_device()
+
+def main(config_name):
+    # Build the SAM2 model
+    sam2_model = build_sam2(config_name, sam2_checkpoint, device=device)
+    
+    # Create the cell tracker
+    tracker = SAM2AutomaticCellTracker(
+        sam2_model,
+        points_per_side=16,  # Fewer points for faster processing
+        pred_iou_thresh=0.7,
+        obj_score_thresh=0,
+        div_obj_score_thresh=0,
+        stability_score_thresh=0.7,
+        box_nms_thresh=0.7,
+        min_mask_region_area=30,
+        use_m2m=True,  # Use mask-to-mask refinement
+    )
+
+    video_path = 'C:/Users/17742/Documents/DeepLearning/datasets/moma/CTC/test/29'
+    res_path = Path(__file__).parents[1] / 'sam2_logs' / model_name / 'results' / 'CTC' / Path(video_path).stem
+    res_path.mkdir(parents=True, exist_ok=True)
+
+    if video_path is None:
+        # Ask user to select video or image folder
+        video_path = get_video_path()
+
+    # Track cells in the video or image sequence
+    tracker.predict(
+        video_path, 
+        res_path,
+        offload_video_to_cpu=True,
+        offload_state_to_cpu=True,
+    )
+    
+
+def get_video_path():
+    # Create and hide the root window
+    root = tk.Tk()
+    root.withdraw()
+    
+    # Ask user if they want to select a video or a folder of images
+    selection_window = tk.Toplevel(root)
+    selection_window.title("Select Input Type")
+    selection_window.geometry("300x150")
+    selection_window.resizable(False, False)
+    
+    selected_option = tk.StringVar(value="video")
+    
+    tk.Label(selection_window, text="Choose input type:").pack(pady=10)
+    tk.Radiobutton(selection_window, text="Video file", variable=selected_option, value="video").pack(anchor=tk.W, padx=20)
+    tk.Radiobutton(selection_window, text="Folder of images", variable=selected_option, value="images").pack(anchor=tk.W, padx=20)
+    
+    path_result = [None]  # Use list to store result from callback
+    
+    def on_confirm():
+        option = selected_option.get()
+        if option == "video":
+            path_result[0] = filedialog.askopenfilename(
+                title="Select a video file",
+                filetypes=[
+                    ("Video files", "*.mp4 *.avi *.mov *.mkv"),
+                    ("All files", "*.*")
+                ]
+            )
+        else:  # images
+            path_result[0] = filedialog.askdirectory(
+                title="Select folder containing image sequence"
+            )
+        selection_window.destroy()
+    
+    tk.Button(selection_window, text="Confirm", command=on_confirm).pack(pady=20)
+    
+    # Wait for the window to be closed
+    selection_window.wait_window()
+    
+    if not path_result[0]:
+        print("No input selected. Exiting...")
+        exit()
+
+    return Path(path_result[0])
+
+if __name__ == "__main__":
+    main(config_name) 

--- a/inference/track_cells.py
+++ b/inference/track_cells.py
@@ -66,6 +66,7 @@ def main(config_name):
         res_path,
         offload_video_to_cpu=True,
         offload_state_to_cpu=True,
+        max_frame_num_to_track=None,
     )
     
 

--- a/inference/track_cells.py
+++ b/inference/track_cells.py
@@ -48,6 +48,7 @@ def main(config_name):
         box_nms_thresh=0.7,
         min_mask_region_area=30,
         use_m2m=True,  # Use mask-to-mask refinement
+        segment=True,
     )
 
     video_path = 'C:/Users/17742/Documents/DeepLearning/datasets/moma/CTC/test/29'

--- a/inference/track_cells.py
+++ b/inference/track_cells.py
@@ -61,6 +61,12 @@ def parse_args():
         default=True,
         help='Whether to use heatmap'
     )
+    parser.add_argument(
+        '--checkpoint_num',
+        type=int,
+        default=None,
+        help='Checkpoint number to use'
+    )
     return parser.parse_args()
 
 def setup_hydra(model_name: str):
@@ -132,7 +138,10 @@ def main():
     
     # Setup model and device
     device = get_device()
-    sam2_checkpoint = f"sam2_logs/{model_name}/checkpoints/checkpoint.pt"
+    if args.checkpoint_num is None:
+        sam2_checkpoint = f"sam2_logs/{model_name}/checkpoints/checkpoint.pt"
+    else:
+        sam2_checkpoint = f"sam2_logs/{model_name}/checkpoints/checkpoint_{args.checkpoint_num}.pt"
     sam2_model = build_sam2(config_name, sam2_checkpoint, device=device)
     
     # Create the cell tracker

--- a/inference/track_cells.py
+++ b/inference/track_cells.py
@@ -63,8 +63,8 @@ def process_directory(
     model_name: str,
     input_path: Path,
     res_path: Path,
-    idx: int,
-    total_dirs: int
+    total_dirs: int,
+    idx: int
 ):
     """Process a single directory with the cell tracker.
     
@@ -87,7 +87,6 @@ def process_directory(
         input_path=input_path,
         dir_name=dir_path.stem,
         res_path=res_path,
-        idx=idx
     )
     result_path.mkdir(parents=True, exist_ok=True)
     
@@ -142,8 +141,8 @@ def main():
                 model_name=model_name,
                 input_path=video_path,
                 res_path=args.res_path,
-                idx=idx,
-                total_dirs=len(directories)
+                total_dirs=len(directories),
+                idx=idx
             )
             
     except ValueError as e:

--- a/inference/track_cells.py
+++ b/inference/track_cells.py
@@ -38,6 +38,29 @@ def parse_args():
         default="SAM2-tracking-LoRA-heatmap",
         help='Name of the model to use'
     )
+    parser.add_argument(
+        '--box_nms_thresh',
+        type=float,
+        default=0.5,
+        help='Non-maximum suppression threshold for bounding boxes'
+    )
+    parser.add_argument(
+        '--pred_iou_thresh',
+        type=float,
+        default=0.7,
+        help='IoU threshold for predictions'
+    )
+    parser.add_argument(
+        '--segment',
+        action='store_true',
+        help='Whether to perform segmentation (default: False)'
+    )
+    parser.add_argument(
+        '--use_heatmap',
+        type=bool,
+        default=True,
+        help='Whether to use heatmap'
+    )
     return parser.parse_args()
 
 def setup_hydra(model_name: str):
@@ -115,13 +138,12 @@ def main():
     # Create the cell tracker
     tracker = SAM2AutomaticCellTracker(
         sam2_model,
-        pred_iou_thresh=0.7,
+        pred_iou_thresh=args.pred_iou_thresh,
         obj_score_thresh=0,
         div_obj_score_thresh=0,
-        stability_score_thresh=0.7,
-        box_nms_thresh=0.7,
-        segment=False,
-        use_heatmap=True,
+        box_nms_thresh=args.box_nms_thresh,
+        segment=args.segment,
+        use_heatmap=args.use_heatmap,
     )
 
     # Get input path

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -74,18 +74,10 @@ def build_sam2(
     device="cuda",
     mode="eval",
     hydra_overrides_extra=[],
-    apply_postprocessing=True,
     **kwargs,
 ):
-
-    if apply_postprocessing:
-        hydra_overrides_extra = hydra_overrides_extra.copy()
-        hydra_overrides_extra += [
-            # dynamically fall back to multi-mask if the single mask is not stable
-            "++model.sam_mask_decoder_extra_args.dynamic_multimask_via_stability=true",
-            "++model.sam_mask_decoder_extra_args.dynamic_multimask_stability_delta=0.05",
-            "++model.sam_mask_decoder_extra_args.dynamic_multimask_stability_thresh=0.98",
-        ]
+    
+    hydra_overrides_extra.append(f"++trainer.lora.mode={mode}")
     # Read config and init model
     cfg = compose(config_name=config_file, overrides=hydra_overrides_extra)
     OmegaConf.resolve(cfg)
@@ -102,51 +94,6 @@ def build_sam2(
         model.eval()
     return model
 
-
-def build_sam2_video_predictor(
-    config_file,
-    ckpt_path=None,
-    device="cuda",
-    mode="eval",
-    hydra_overrides_extra=[],
-    apply_postprocessing=True,
-    vos_optimized=False,
-    **kwargs,
-):
-    hydra_overrides = [
-        "++model._target_=sam2.sam2_video_predictor.SAM2VideoPredictor",
-    ]
-    if vos_optimized:
-        hydra_overrides = [
-            "++model._target_=sam2.sam2_video_predictor.SAM2VideoPredictorVOS",
-            "++model.compile_image_encoder=True",  # Let sam2_base handle this
-        ]
-
-    if apply_postprocessing:
-        hydra_overrides_extra = hydra_overrides_extra.copy()
-        hydra_overrides_extra += [
-            # dynamically fall back to multi-mask if the single mask is not stable
-            "++model.sam_mask_decoder_extra_args.dynamic_multimask_via_stability=true",
-            "++model.sam_mask_decoder_extra_args.dynamic_multimask_stability_delta=0.05",
-            "++model.sam_mask_decoder_extra_args.dynamic_multimask_stability_thresh=0.98",
-            # the sigmoid mask logits on interacted frames with clicks in the memory encoder so that the encoded masks are exactly as what users see from clicking
-            "++model.binarize_mask_from_pts_for_mem_enc=true",
-            # fill small holes in the low-res masks up to `fill_hole_area` (before resizing them to the original video resolution)
-            "++model.fill_hole_area=8",
-        ]
-    hydra_overrides.extend(hydra_overrides_extra)
-
-    # Read config and init model
-    cfg = compose(config_name=config_file, overrides=hydra_overrides)
-    OmegaConf.resolve(cfg)
-    model = instantiate(cfg.model, _recursive_=True)
-    _load_checkpoint(model, ckpt_path)
-    model = model.to(device)
-    if mode == "eval":
-        model.eval()
-    return model
-
-
 def _hf_download(model_id):
     from huggingface_hub import hf_hub_download
 
@@ -158,13 +105,6 @@ def _hf_download(model_id):
 def build_sam2_hf(model_id, **kwargs):
     config_name, ckpt_path = _hf_download(model_id)
     return build_sam2(config_file=config_name, ckpt_path=ckpt_path, **kwargs)
-
-
-def build_sam2_video_predictor_hf(model_id, **kwargs):
-    config_name, ckpt_path = _hf_download(model_id)
-    return build_sam2_video_predictor(
-        config_file=config_name, ckpt_path=ckpt_path, **kwargs
-    )
 
 
 def _load_checkpoint(model, ckpt_path, strict=True):

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -2,13 +2,13 @@
 
 scratch:
   resolution: 512
+  batch_size: 1
   num_train_workers: 2
   num_frames: 4
   max_num_objects: 30
   max_num_bkgd_objects: 8
   base_lr: 5.0e-6
   vision_lr: 3.0e-06
-  phases_per_epoch: 1
   num_epochs: 20
   use_lora: True 
   lora_lr: 1.0e-3
@@ -68,11 +68,25 @@ vos:
         - _target_: training.dataset.transforms.NormalizeAPI
           mean: [0.485, 0.456, 0.406]
           std: [0.229, 0.224, 0.225]
+  val_transforms:
+    - _target_: training.dataset.transforms.ComposeAPI
+      transforms:
+        - _target_: training.dataset.transforms.RandomResizeAPI
+          sizes: ${scratch.resolution}
+          square: false
+          max_size: ${scratch.resolution}
+          consistent_transform: True
+        - _target_: training.dataset.transforms.PadToSquareAPI
+          size: ${scratch.resolution}
+        - _target_: training.dataset.transforms.ToTensorAPI
+        - _target_: training.dataset.transforms.NormalizeAPI
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
 
 trainer:
   _target_: training.trainer.Trainer
   mode: train
-  max_epochs: ${times:${scratch.num_epochs},${scratch.phases_per_epoch}}
+  max_epochs: ${scratch.num_epochs}
   accelerator: cuda
   seed_value: 123
   freeze_encoder: ${scratch.freeze_encoder}
@@ -239,11 +253,10 @@ trainer:
 
   data:
     train:
-      _target_: training.dataset.sam2_datasets.TorchTrainMixedDataset
-      phases_per_epoch: 1
-      batch_sizes: [1]
-      datasets:
-        - _target_: training.dataset.vos_dataset.VOSDataset
+      _target_: training.dataset.sam2_datasets.SingleDataLoader
+      batch_size: ${scratch.batch_size}
+      dataset:
+          _target_: training.dataset.vos_dataset.VOSDataset
           training: true
           transforms: ${vos.train_transforms}
           video_dataset:
@@ -252,10 +265,10 @@ trainer:
             num_frames: ${scratch.num_frames}
             file_list_txt: ${dataset.file_list_txt}  # optional
           sampler:
-            _target_: training.dataset.vos_sampler.RandomUniformSampler
-            num_frames: ${scratch.num_frames}
+            _target_: training.dataset.vos_sampler.FrameIndexSampler
             max_num_objects: ${scratch.max_num_objects}
             max_num_bkgd_objects: ${scratch.max_num_bkgd_objects}
+            is_training: true
           multiplier: ${dataset.multiplier}
       shuffle: True
       num_workers: ${scratch.num_train_workers}
@@ -266,25 +279,24 @@ trainer:
         _partial_: true
         dict_key: all
     val:
-      _target_: training.dataset.sam2_datasets.TorchTrainMixedDataset
-      phases_per_epoch: 1
-      batch_sizes: [1]
-      datasets:
-        - _target_: training.dataset.vos_dataset.VOSDataset
+      _target_: training.dataset.sam2_datasets.SingleDataLoader
+      batch_size: ${scratch.batch_size}
+      dataset:
+          _target_: training.dataset.vos_dataset.VOSDataset
           training: false
-          transforms: ${vos.train_transforms}
+          transforms: ${vos.val_transforms}
           video_dataset:
             _target_: training.dataset.vos_raw_dataset.CTCRawDataset
             train_dir: ${dataset.data_dir}/val/CTC
             num_frames: ${scratch.num_frames}
             file_list_txt: ${dataset.file_list_txt}  # optional
           sampler:
-            _target_: training.dataset.vos_sampler.RandomUniformSampler
-            num_frames: ${scratch.num_frames}
+            _target_: training.dataset.vos_sampler.FrameIndexSampler
             max_num_objects: ${scratch.max_num_objects}
             max_num_bkgd_objects: ${scratch.max_num_bkgd_objects}
+            is_training: false
           multiplier: ${dataset.multiplier}
-      shuffle: True
+      shuffle: False
       num_workers: ${scratch.num_train_workers}
       pin_memory: True
       drop_last: True

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -343,6 +343,7 @@ trainer:
         loss_iou: 1
         loss_class: 1
         loss_div: 1
+        loss_heatmap: 1
       supervise_all_iou: true
       iou_use_l1_loss: true
       pred_obj_scores: true

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -81,6 +81,7 @@ trainer:
     adapt_mlp: true
     trainable_iou_pred_heads: true
     trainable_obj_score_heads: true
+    mode: train
 
   model:
     _target_: training.model.sam2.SAM2Train

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -201,6 +201,10 @@ trainer:
     # Compilation flag
     # compile_image_encoder: False
 
+    pred_iou_thresh: 0.7
+    obj_score_thresh: 0.5
+    div_obj_score_thresh: 0.5
+
     ####### Training specific params #######
     # box/point input and corrections
     prob_to_use_pt_input_for_train: 1

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -3,7 +3,7 @@
 scratch:
   resolution: 512
   num_train_workers: 2
-  num_frames: 1
+  num_frames: 4
   max_num_objects: 12
   max_num_bkgd_objects: 4
   base_lr: 5.0e-6
@@ -13,7 +13,7 @@ scratch:
   use_lora: True 
   lora_lr: 1.0e-3
   use_wandb: False
-  freeze_encoder: True
+  freeze_encoder: False
 
 dataset:
   # PATHS to Dataset
@@ -188,6 +188,9 @@ trainer:
     pred_obj_scores: true
     pred_obj_scores_mlp: true
     fixed_no_obj_ptr: true
+    # cell division prediction
+    pred_div_scores: true
+    pred_div_scores_mlp: true
     # multimask tracking settings
     multimask_output_for_tracking: true
     use_multimask_token_for_obj_ptr: true
@@ -199,19 +202,19 @@ trainer:
 
     ####### Training specific params #######
     # box/point input and corrections
-    prob_to_use_pt_input_for_train: 0.5
+    prob_to_use_pt_input_for_train: 1
     prob_to_use_pt_input_for_eval: 0.0
     prob_to_use_box_input_for_train: 0.5  # 0.5*0.5 = 0.25 prob to use box instead of points
     prob_to_use_box_input_for_eval: 0.0
     prob_to_sample_from_gt_for_train: 0.1  # with a small prob, sampling correction points from GT mask instead of prediction errors
-    num_frames_to_correct_for_train: 2  # iteratively sample on random 1~2 frames (always include the first frame)
+    num_frames_to_correct_for_train: 1  # iteratively sample on random 1~2 frames (always include the first frame)
     num_frames_to_correct_for_eval: 1  # only iteratively sample on first frame
     rand_frames_to_correct_for_train: True  # random #init-cond-frame ~ 2
     add_all_frames_to_correct_as_cond: True  # when a frame receives a correction click, it becomes a conditioning frame (even if it's not initially a conditioning frame)
     # maximum 2 initial conditioning frames
-    num_init_cond_frames_for_train: 2
+    num_init_cond_frames_for_train: 1
     rand_init_cond_frames_for_train: True  # random 1~2
-    num_correction_pt_per_frame: 7
+    num_correction_pt_per_frame: 5
     use_act_ckpt_iterative_pt_sampling: false
     
 
@@ -224,7 +227,7 @@ trainer:
     train:
       _target_: training.dataset.sam2_datasets.TorchTrainMixedDataset
       phases_per_epoch: 1
-      batch_sizes: [2]
+      batch_sizes: [1]
       datasets:
         - _target_: training.dataset.vos_dataset.VOSDataset
           training: true
@@ -251,7 +254,7 @@ trainer:
     val:
       _target_: training.dataset.sam2_datasets.TorchTrainMixedDataset
       phases_per_epoch: 1
-      batch_sizes: [2]
+      batch_sizes: [1]
       datasets:
         - _target_: training.dataset.vos_dataset.VOSDataset
           training: false

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -4,8 +4,8 @@ scratch:
   resolution: 512
   num_train_workers: 2
   num_frames: 4
-  max_num_objects: 12
-  max_num_bkgd_objects: 4
+  max_num_objects: 30
+  max_num_bkgd_objects: 8
   base_lr: 5.0e-6
   vision_lr: 3.0e-06
   phases_per_epoch: 1
@@ -17,7 +17,7 @@ scratch:
 
 dataset:
   # PATHS to Dataset
-  data_dir: ../datasets/moma/CTC # PATH to MOSE JPEGImages folder
+  data_dir: ../data/moma
   file_list_txt: # Optional PATH to filelist containing a subset of videos to be used for training
   multiplier: 1
 
@@ -55,6 +55,15 @@ vos:
           contrast: 0.05
           saturation: 0.05
           hue: null
+        - _target_: training.dataset.transforms.RandomGaussianBlur
+          p: 0.4
+          sigma: [0.1,1.5]
+        - _target_: training.dataset.transforms.RandomGaussianNoise
+          p: 0.4
+          sigma: 0.05
+        - _target_: training.dataset.transforms.RandomIlluminationVoodoo
+          p: 0.4
+          num_control_points: 5
         - _target_: training.dataset.transforms.ToTensorAPI
         - _target_: training.dataset.transforms.NormalizeAPI
           mean: [0.485, 0.456, 0.406]
@@ -239,7 +248,7 @@ trainer:
           transforms: ${vos.train_transforms}
           video_dataset:
             _target_: training.dataset.vos_raw_dataset.CTCRawDataset
-            train_dir: ${dataset.data_dir}/train
+            train_dir: ${dataset.data_dir}/train/CTC
             num_frames: ${scratch.num_frames}
             file_list_txt: ${dataset.file_list_txt}  # optional
           sampler:
@@ -266,7 +275,7 @@ trainer:
           transforms: ${vos.train_transforms}
           video_dataset:
             _target_: training.dataset.vos_raw_dataset.CTCRawDataset
-            train_dir: ${dataset.data_dir}/val
+            train_dir: ${dataset.data_dir}/val/CTC
             num_frames: ${scratch.num_frames}
             file_list_txt: ${dataset.file_list_txt}  # optional
           sampler:

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -387,7 +387,7 @@ trainer:
   # initialize from a SAM 2 checkpoint
   checkpoint:
     save_dir: ${launcher.experiment_log_dir}/checkpoints
-    save_freq: 0 # 0 only last checkpoint is saved.
+    save_freq: 1 # Checkpoint is saved every epoch.
     model_weight_initializer:
       _partial_: True
       _target_: training.utils.checkpoint_utils.load_state_dict_into_model

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -203,7 +203,7 @@ trainer:
     ####### Training specific params #######
     # box/point input and corrections
     prob_to_use_pt_input_for_train: 1
-    prob_to_use_pt_input_for_eval: 0.0
+    prob_to_use_pt_input_for_eval: 1
     prob_to_use_box_input_for_train: 0.5  # 0.5*0.5 = 0.25 prob to use box instead of points
     prob_to_use_box_input_for_eval: 0.0
     prob_to_sample_from_gt_for_train: 0.1  # with a small prob, sampling correction points from GT mask instead of prediction errors

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune.yaml
@@ -337,6 +337,7 @@ trainer:
         loss_dice: 1
         loss_iou: 1
         loss_class: 1
+        loss_div: 1
       supervise_all_iou: true
       iou_use_l1_loss: true
       pred_obj_scores: true

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -17,7 +17,7 @@ scratch:
 
 dataset:
   # PATHS to Dataset
-  data_dir: ../datasets/moma/CTC # PATH to MOSE JPEGImages folder
+  data_dir: ../data/moma
   file_list_txt: # Optional PATH to filelist containing a subset of videos to be used for training
   multiplier: 1
 
@@ -55,6 +55,15 @@ vos:
           contrast: 0.05
           saturation: 0.05
           hue: null
+        - _target_: training.dataset.transforms.RandomGaussianBlur
+          p: 0.4
+          sigma: [0.1,1.5]
+        - _target_: training.dataset.transforms.RandomGaussianNoise
+          p: 0.4
+          sigma: 0.05
+        - _target_: training.dataset.transforms.RandomIlluminationVoodoo
+          p: 0.4
+          num_control_points: 5
         - _target_: training.dataset.transforms.ToTensorAPI
         - _target_: training.dataset.transforms.NormalizeAPI
           mean: [0.485, 0.456, 0.406]
@@ -239,7 +248,7 @@ trainer:
           transforms: ${vos.train_transforms}
           video_dataset:
             _target_: training.dataset.vos_raw_dataset.CTCRawDataset
-            train_dir: ${dataset.data_dir}/train
+            train_dir: ${dataset.data_dir}/train/CTC
             num_frames: ${scratch.num_frames}
             file_list_txt: ${dataset.file_list_txt}  # optional
           sampler:
@@ -266,7 +275,7 @@ trainer:
           transforms: ${vos.train_transforms}
           video_dataset:
             _target_: training.dataset.vos_raw_dataset.CTCRawDataset
-            train_dir: ${dataset.data_dir}/val
+            train_dir: ${dataset.data_dir}/val/CTC
             num_frames: ${scratch.num_frames}
             file_list_txt: ${dataset.file_list_txt}  # optional
           sampler:

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -2,13 +2,13 @@
 
 scratch:
   resolution: 512
+  batch_size: 1
   num_train_workers: 0
   num_frames: 3
   max_num_objects: 12
   max_num_bkgd_objects: 4
   base_lr: 5.0e-6
   vision_lr: 3.0e-06
-  phases_per_epoch: 1
   num_epochs: 20
   use_lora: True 
   lora_lr: 1.0e-3
@@ -68,11 +68,25 @@ vos:
         - _target_: training.dataset.transforms.NormalizeAPI
           mean: [0.485, 0.456, 0.406]
           std: [0.229, 0.224, 0.225]
+  val_transforms:
+    - _target_: training.dataset.transforms.ComposeAPI
+      transforms:
+        - _target_: training.dataset.transforms.RandomResizeAPI
+          sizes: ${scratch.resolution}
+          square: false
+          max_size: ${scratch.resolution}
+          consistent_transform: True
+        - _target_: training.dataset.transforms.PadToSquareAPI
+          size: ${scratch.resolution}
+        - _target_: training.dataset.transforms.ToTensorAPI
+        - _target_: training.dataset.transforms.NormalizeAPI
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
 
 trainer:
   _target_: training.trainer.Trainer
   mode: train
-  max_epochs: ${times:${scratch.num_epochs},${scratch.phases_per_epoch}}
+  max_epochs: ${scratch.num_epochs}
   accelerator: cpu
   seed_value: 123
   freeze_encoder: ${scratch.freeze_encoder}
@@ -239,11 +253,10 @@ trainer:
 
   data:
     train:
-      _target_: training.dataset.sam2_datasets.TorchTrainMixedDataset
-      phases_per_epoch: 1
-      batch_sizes: [1]
-      datasets:
-        - _target_: training.dataset.vos_dataset.VOSDataset
+      _target_: training.dataset.sam2_datasets.SingleDataLoader
+      batch_size: ${scratch.batch_size}
+      dataset:
+          _target_: training.dataset.vos_dataset.VOSDataset
           training: true
           transforms: ${vos.train_transforms}
           video_dataset:
@@ -252,10 +265,10 @@ trainer:
             num_frames: ${scratch.num_frames}
             file_list_txt: ${dataset.file_list_txt}  # optional
           sampler:
-            _target_: training.dataset.vos_sampler.RandomUniformSampler
-            num_frames: ${scratch.num_frames}
+            _target_: training.dataset.vos_sampler.FrameIndexSampler
             max_num_objects: ${scratch.max_num_objects}
             max_num_bkgd_objects: ${scratch.max_num_bkgd_objects}
+            is_training: true
           multiplier: ${dataset.multiplier}
       shuffle: True
       num_workers: ${scratch.num_train_workers}
@@ -266,25 +279,24 @@ trainer:
         _partial_: true
         dict_key: all
     val:
-      _target_: training.dataset.sam2_datasets.TorchTrainMixedDataset
-      phases_per_epoch: 1
-      batch_sizes: [1]
-      datasets:
-        - _target_: training.dataset.vos_dataset.VOSDataset
+      _target_: training.dataset.sam2_datasets.SingleDataLoader
+      batch_size: ${scratch.batch_size}
+      dataset:
+          _target_: training.dataset.vos_dataset.VOSDataset
           training: false
-          transforms: ${vos.train_transforms}
+          transforms: ${vos.val_transforms}
           video_dataset:
             _target_: training.dataset.vos_raw_dataset.CTCRawDataset
             train_dir: ${dataset.data_dir}/val/CTC
             num_frames: ${scratch.num_frames}
             file_list_txt: ${dataset.file_list_txt}  # optional
           sampler:
-            _target_: training.dataset.vos_sampler.RandomUniformSampler
-            num_frames: ${scratch.num_frames}
+            _target_: training.dataset.vos_sampler.FrameIndexSampler
             max_num_objects: ${scratch.max_num_objects}
             max_num_bkgd_objects: ${scratch.max_num_bkgd_objects}
+            is_training: false
           multiplier: ${dataset.multiplier}
-      shuffle: True
+      shuffle: False
       num_workers: ${scratch.num_train_workers}
       pin_memory: True
       drop_last: True

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -343,6 +343,7 @@ trainer:
         loss_iou: 1
         loss_class: 1
         loss_div: 1
+        loss_heatmap: 1
       supervise_all_iou: true
       iou_use_l1_loss: true
       pred_obj_scores: true

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -2,9 +2,8 @@
 
 scratch:
   resolution: 512
-  train_batch_size: 1
   num_train_workers: 0
-  num_frames: 2
+  num_frames: 3
   max_num_objects: 12
   max_num_bkgd_objects: 4
   base_lr: 5.0e-6
@@ -188,7 +187,10 @@ trainer:
     # object occlusion prediction
     pred_obj_scores: true
     pred_obj_scores_mlp: true
-    fixed_no_obj_ptr: true
+    fixed_no_obj_ptr: true    
+    # cell division prediction
+    pred_div_scores: true
+    pred_div_scores_mlp: true
     # multimask tracking settings
     multimask_output_for_tracking: true
     use_multimask_token_for_obj_ptr: true
@@ -212,7 +214,7 @@ trainer:
     # maximum 2 initial conditioning frames
     num_init_cond_frames_for_train: 1
     rand_init_cond_frames_for_train: True  # random 1~2
-    num_correction_pt_per_frame: 7
+    num_correction_pt_per_frame: 2
     use_act_ckpt_iterative_pt_sampling: false
     
 

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -81,6 +81,7 @@ trainer:
     adapt_mlp: true
     trainable_iou_pred_heads: true
     trainable_obj_score_heads: true
+    mode: train
 
   model:
     _target_: training.model.sam2.SAM2Train

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -201,6 +201,10 @@ trainer:
     # Compilation flag
     # compile_image_encoder: False
 
+    pred_iou_thresh: 0.7
+    obj_score_thresh: 0.5
+    div_obj_score_thresh: 0.5
+
     ####### Training specific params #######
     # box/point input and corrections
     prob_to_use_pt_input_for_train: 1

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -387,7 +387,7 @@ trainer:
   # initialize from a SAM 2 checkpoint
   checkpoint:
     save_dir: ${launcher.experiment_log_dir}/checkpoints
-    save_freq: 0 # 0 only last checkpoint is saved.
+    save_freq: 1 # Checkpoint is saved every epoch.
     model_weight_initializer:
       _partial_: True
       _target_: training.utils.checkpoint_utils.load_state_dict_into_model

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -203,7 +203,7 @@ trainer:
     ####### Training specific params #######
     # box/point input and corrections
     prob_to_use_pt_input_for_train: 1
-    prob_to_use_pt_input_for_eval: 0.0
+    prob_to_use_pt_input_for_eval: 1
     prob_to_use_box_input_for_train: 0.5  # 0.5*0.5 = 0.25 prob to use box instead of points
     prob_to_use_box_input_for_eval: 0.0
     prob_to_sample_from_gt_for_train: 0.1  # with a small prob, sampling correction points from GT mask instead of prediction errors

--- a/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
+++ b/sam2/configs/sam2.1_training/sam2.1_ctc_finetune_cpu.yaml
@@ -337,6 +337,7 @@ trainer:
         loss_dice: 1
         loss_iou: 1
         loss_class: 1
+        loss_div: 1
       supervise_all_iou: true
       iou_use_l1_loss: true
       pred_obj_scores: true

--- a/sam2/modeling/sam/mask_decoder.py
+++ b/sam2/modeling/sam/mask_decoder.py
@@ -59,7 +59,6 @@ class MaskDecoder(nn.Module):
         self.iou_token = nn.Embedding(1, transformer_dim)
         self.num_mask_tokens = num_multimask_outputs + 1
         self.mask_tokens = nn.Embedding(self.num_mask_tokens, transformer_dim)
-        self.division_tokens = nn.Embedding(1, transformer_dim)
 
         self.pred_obj_scores = pred_obj_scores
         if self.pred_obj_scores:
@@ -251,7 +250,7 @@ class MaskDecoder(nn.Module):
 
         if self.pred_div_scores:
             output_tokens = torch.cat(
-                [output_tokens, self.division_tokens.weight], dim=0
+                [output_tokens, self.div_score_token.weight], dim=0
             )
 
         output_tokens = output_tokens.unsqueeze(0).expand(

--- a/sam2/modeling/sam/mask_decoder.py
+++ b/sam2/modeling/sam/mask_decoder.py
@@ -8,8 +8,9 @@ from typing import List, Optional, Tuple, Type
 
 import torch
 from torch import nn
+import torch.nn.functional as F
 
-from sam2.modeling.sam2_utils import LayerNorm2d, MLP
+from sam2.modeling.sam2_utils import LayerNorm2d, MLP, compute_iou
 
 
 class MaskDecoder(nn.Module):
@@ -30,6 +31,8 @@ class MaskDecoder(nn.Module):
         pred_obj_scores: bool = False,
         pred_obj_scores_mlp: bool = False,
         use_multimask_token_for_obj_ptr: bool = False,
+        pred_div_scores: bool = False,
+        pred_div_scores_mlp: bool = False,
     ) -> None:
         """
         Predicts masks given an image and prompt embeddings, using a
@@ -56,10 +59,16 @@ class MaskDecoder(nn.Module):
         self.iou_token = nn.Embedding(1, transformer_dim)
         self.num_mask_tokens = num_multimask_outputs + 1
         self.mask_tokens = nn.Embedding(self.num_mask_tokens, transformer_dim)
+        self.division_tokens = nn.Embedding(1, transformer_dim)
 
         self.pred_obj_scores = pred_obj_scores
         if self.pred_obj_scores:
             self.obj_score_token = nn.Embedding(1, transformer_dim)
+
+        self.pred_div_scores = pred_div_scores
+        if self.pred_div_scores:
+            self.div_score_token = nn.Embedding(1, transformer_dim)
+
         self.use_multimask_token_for_obj_ptr = use_multimask_token_for_obj_ptr
 
         self.output_upscaling = nn.Sequential(
@@ -101,6 +110,11 @@ class MaskDecoder(nn.Module):
             if pred_obj_scores_mlp:
                 self.pred_obj_score_head = MLP(transformer_dim, transformer_dim, 1, 3)
 
+        if self.pred_div_scores:
+            self.pred_div_score_head = nn.Linear(transformer_dim, 1)
+            if pred_div_scores_mlp:
+                self.pred_div_score_head = MLP(transformer_dim, transformer_dim, 1, 3)
+
         # When outputting a single mask, optionally we can dynamically fall back to the best
         # multimask output token if the single mask output token gives low stability scores.
         self.dynamic_multimask_via_stability = dynamic_multimask_via_stability
@@ -113,10 +127,11 @@ class MaskDecoder(nn.Module):
         image_pe: torch.Tensor,
         sparse_prompt_embeddings: torch.Tensor,
         dense_prompt_embeddings: torch.Tensor,
-        multimask_output: bool,
         repeat_image: bool,
         high_res_features: Optional[List[torch.Tensor]] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        is_dividing: Optional[torch.Tensor] = None,
+        gt_masks: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Predict masks given image and prompt embeddings.
 
@@ -125,15 +140,21 @@ class MaskDecoder(nn.Module):
           image_pe (torch.Tensor): positional encoding with the shape of image_embeddings
           sparse_prompt_embeddings (torch.Tensor): the embeddings of the points and boxes
           dense_prompt_embeddings (torch.Tensor): the embeddings of the mask inputs
-          multimask_output (bool): Whether to return multiple masks or a single
-            mask.
+          repeat_image (bool): whether to repeat the image embeddings for each prompt
+          high_res_features (Optional[List[torch.Tensor]]): optional high resolution features
+          is_dividing (Optional[torch.Tensor]): optional tensor indicating dividing cells for training
+          gt_masks (Optional[torch.Tensor]): ground truth masks for training
 
         Returns:
           torch.Tensor: batched predicted masks
           torch.Tensor: batched predictions of mask quality
           torch.Tensor: batched SAM token for mask output
+          torch.Tensor: batched object score logits
+          torch.Tensor: batched division score logits
+          torch.Tensor: batched post-split object score logits
+          torch.Tensor: batched is_dividing
         """
-        masks, iou_pred, mask_tokens_out, object_score_logits = self.predict_masks(
+        masks, iou_pred, mask_tokens_out, object_score_logits, div_score_logits = self.predict_masks(
             image_embeddings=image_embeddings,
             image_pe=image_pe,
             sparse_prompt_embeddings=sparse_prompt_embeddings,
@@ -142,28 +163,64 @@ class MaskDecoder(nn.Module):
             high_res_features=high_res_features,
         )
 
-        # Select the correct mask or masks for output
-        if multimask_output:
-            masks = masks[:, 1:, :, :]
-            iou_pred = iou_pred[:, 1:]
-        elif self.dynamic_multimask_via_stability and not self.training:
-            masks, iou_pred = self._dynamic_multimask_via_stability(masks, iou_pred)
-        else:
-            masks = masks[:, 0:1, :, :]
-            iou_pred = iou_pred[:, 0:1]
+        # Determine which cells are dividing
+        if is_dividing is None:
+            is_dividing = (div_score_logits > 0) & (object_score_logits > 0)
+        
+        # Ensure is_dividing is a flat boolean tensor
+        is_dividing = is_dividing.view(-1)
+        
+        # Create masks for dividing and non-dividing cells
+        div_mask = is_dividing  # [B] bool
+        no_div_mask = ~div_mask
 
-        if multimask_output and self.use_multimask_token_for_obj_ptr:
-            sam_tokens_out = mask_tokens_out[:, 1:]  # [b, 3, c] shape
-        else:
-            # Take the mask output token. Here we *always* use the token for single mask output.
-            # At test time, even if we track after 1-click (and using multimask_output=True),
-            # we still take the single mask token here. The rationale is that we always track
-            # after multiple clicks during training, so the past tokens seen during training
-            # are always the single mask token (and we'll let it be the object-memory token).
-            sam_tokens_out = mask_tokens_out[:, 0:1]  # [b, 1, c] shape
+        # Handle non-dividing cells (single mask per cell)
+        pred_masks = masks[no_div_mask, 0:1]  # Keep dim for proper shape
+        pred_ious = iou_pred[no_div_mask, 0:1]
+        pred_tokens = mask_tokens_out[no_div_mask, 0:1]
 
-        # Prepare output
-        return masks, iou_pred, sam_tokens_out, object_score_logits
+        # Process dividing cells if any exist
+        if div_mask.sum() > 0:
+            # During training with GT masks, match daughter masks to ground truth
+            if self.training and gt_masks is not None:
+                pred_div_masks, pred_div_ious, pred_div_tokens = self._match_daughter_masks_to_gt(
+                    gt_masks, masks, iou_pred, mask_tokens_out, div_mask
+                )
+            else:
+                # For inference or when GT masks aren't provided
+                # Extract masks 1 and 2 for dividing cells and reshape
+                pred_div_masks = masks[div_mask][:, 1:3]  # [N, 2, H, W]
+                pred_div_ious = iou_pred[div_mask][:, 1:3]  # [N, 2]
+                pred_div_tokens = mask_tokens_out[div_mask][:, 1:3]  # [N, 2, C]
+                
+                # Reshape to have each mask as a separate item in batch
+                pred_div_masks = pred_div_masks.flatten(0, 1).unsqueeze(1)  # [N*2, 1, H, W]
+                pred_div_ious = pred_div_ious.flatten(0, 1).unsqueeze(1)  # [N*2, 1]
+                pred_div_tokens = pred_div_tokens.flatten(0, 1).unsqueeze(1)  # [N*2, 1, C]
+
+            # Combine results from non-dividing and dividing cells
+            pred_masks = torch.cat([pred_masks, pred_div_masks], dim=0)
+            pred_ious = torch.cat([pred_ious, pred_div_ious], dim=0)
+            pred_tokens = torch.cat([pred_tokens, pred_div_tokens], dim=0)
+
+        # Update object_score_logits to match the new output structure
+        post_split_object_score_logits = None
+        if object_score_logits is not None:
+            # For non-dividing cells, keep single score
+            pred_scores = object_score_logits[no_div_mask]
+            
+            # Handle dividing cells if any exist
+            if div_mask.any():
+                # For dividing cells, duplicate scores for both daughter cells
+                pred_div_scores = object_score_logits[div_mask].repeat_interleave(2, dim=0)
+                # Combine scores
+                post_split_object_score_logits = torch.cat([pred_scores, pred_div_scores], dim=0)
+            else:
+                # If no dividing cells, just use the non-dividing scores
+                post_split_object_score_logits = pred_scores
+
+        # Return all outputs
+        return pred_masks, pred_ious, pred_tokens, object_score_logits, div_score_logits, post_split_object_score_logits, is_dividing
 
     def predict_masks(
         self,
@@ -191,6 +248,12 @@ class MaskDecoder(nn.Module):
             output_tokens = torch.cat(
                 [self.iou_token.weight, self.mask_tokens.weight], dim=0
             )
+
+        if self.pred_div_scores:
+            output_tokens = torch.cat(
+                [output_tokens, self.division_tokens.weight], dim=0
+            )
+
         output_tokens = output_tokens.unsqueeze(0).expand(
             sparse_prompt_embeddings.size(0), -1, -1
         )
@@ -242,7 +305,12 @@ class MaskDecoder(nn.Module):
             # Obj scores logits - default to 10.0, i.e. assuming the object is present, sigmoid(10)=1
             object_score_logits = 10.0 * iou_pred.new_ones(iou_pred.shape[0], 1)
 
-        return masks, iou_pred, mask_tokens_out, object_score_logits
+        if self.pred_div_scores:
+            div_score_logits = self.pred_div_score_head(hs[:, -1, :])
+        else:
+            div_score_logits = -float('inf') * iou_pred.new_ones(iou_pred.shape[0], 1)
+
+        return masks, iou_pred, mask_tokens_out, object_score_logits, div_score_logits
 
     def _get_stability_scores(self, mask_logits):
         """
@@ -293,3 +361,65 @@ class MaskDecoder(nn.Module):
             best_multimask_iou_scores,
         )
         return mask_logits_out, iou_scores_out
+
+    def _match_daughter_masks_to_gt(self, gt_masks, masks, iou_pred, mask_tokens_out, div_mask):
+        """
+        Match predicted daughter cell masks to ground truth masks by computing IoUs
+        and reordering them to maximize the match.
+        
+        For dividing cells, this ensures the predicted daughter masks are correctly
+        aligned with their corresponding ground truth masks by comparing IoUs in
+        both possible orderings and selecting the ordering with the highest total IoU.
+        
+        Args:
+            gt_masks: Ground truth masks
+            masks: Predicted masks
+            iou_pred: Predicted IoU scores
+            mask_tokens_out: Mask tokens output from transformer
+            div_mask: Boolean mask indicating which cells are dividing
+            
+        Returns:
+            Tuple of reordered masks, IoU predictions, and mask tokens
+        """
+        
+        assert self.training
+        pred_div_masks = masks[div_mask][:, 1:3]
+        pred_div_masks_sigmoid = pred_div_masks.sigmoid()  # Take masks 1 and 2
+        pred_div_ious = iou_pred[div_mask][:, 1:3]
+        pred_div_tokens = mask_tokens_out[div_mask][:, 1:3]
+
+        # Daughter masks are alwaays added last
+        gts = gt_masks[-div_mask.sum()*2:].reshape(-1, 2, *gt_masks.shape[-2:])      # [N, 2, H, W]
+        # Resize GT masks to match prediction size
+        gts = F.interpolate(
+            gts.flatten(0, 1).unsqueeze(1).float(),  # [N*2, 1, H, W]
+            size=pred_div_masks.shape[-2:],
+            mode="bilinear",
+            align_corners=False,
+        ).squeeze(1).reshape(-1, 2, *pred_div_masks.shape[-2:])  # [N, 2, h, w]
+        
+        # First ordering: pred[0] with gt[0], pred[1] with gt[1]
+        iou_00 = compute_iou(pred_div_masks_sigmoid[:,0], gts[:,0])
+        iou_11 = compute_iou(pred_div_masks_sigmoid[:,1], gts[:,1])
+        sum_iou_01 = iou_00 + iou_11
+
+        # Swapped ordering: pred[0] with gt[1], pred[1] with gt[0]
+        iou_01 = compute_iou(pred_div_masks_sigmoid[:,0], gts[:,1])
+        iou_10 = compute_iou(pred_div_masks_sigmoid[:,1], gts[:,0])
+        sum_iou_10 = iou_01 + iou_10
+
+        # Choose better match
+        swap = sum_iou_10 > sum_iou_01  # [N] bool
+
+        # Create index tensor [N, 2] where each row is [0,1] or [1,0]
+        order = torch.stack([
+            torch.where(swap, torch.tensor(1, device=pred_div_masks.device), torch.tensor(0, device=pred_div_masks.device)),
+            torch.where(swap, torch.tensor(0, device=pred_div_masks.device), torch.tensor(1, device=pred_div_masks.device))
+        ], dim=1)  # [N, 2]
+
+        # Reorder predictions accordingly
+        pred_div_masks = torch.gather(pred_div_masks, dim=1, index=order.unsqueeze(-1).unsqueeze(-1).expand(-1, -1, pred_div_masks.size(2), pred_div_masks.size(3))).flatten(1).reshape(-1, 1, *pred_div_masks.shape[-2:])
+        pred_div_ious = torch.gather(pred_div_ious, dim=1, index=order).flatten(1).reshape(-1, 1)
+        pred_div_tokens = torch.gather(pred_div_tokens, dim=1, index=order.unsqueeze(-1).expand(-1, -1, pred_div_tokens.size(2))).flatten(1).reshape(-1, 1, pred_div_tokens.shape[-1])
+
+        return pred_div_masks, pred_div_ious, pred_div_tokens

--- a/sam2/modeling/sam/mask_decoder.py
+++ b/sam2/modeling/sam/mask_decoder.py
@@ -218,8 +218,10 @@ class MaskDecoder(nn.Module):
                 # If no dividing cells, just use the non-dividing scores
                 post_split_object_score_logits = pred_scores
 
+        object_score_logits_dict = {"pre_div" : object_score_logits, "post_div" : post_split_object_score_logits}
+
         # Return all outputs
-        return pred_masks, pred_ious, pred_tokens, object_score_logits, div_score_logits, post_split_object_score_logits, is_dividing
+        return pred_masks, pred_ious, pred_tokens, object_score_logits_dict, div_score_logits, is_dividing
 
     def predict_masks(
         self,

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -972,8 +972,9 @@ class SAM2Base(torch.nn.Module):
         if maskmem_features is None or maskmem_pos_enc is None:
             return
             
-        # Store position encoding
-        memory_dict["mask_mem_pos_enc"] = maskmem_pos_enc[0]
+        if memory_dict["mask_mem_pos_enc"] is None:
+            # Store position encoding
+            memory_dict["mask_mem_pos_enc"] = maskmem_pos_enc[0]
         
         # Update memory features for each tracked object
         for i, object_id in enumerate(tracking_object_ids):

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -93,6 +93,10 @@ class SAM2Base(torch.nn.Module):
         # extra arguments used to construct the SAM mask decoder; if not None, it should be a dict of kwargs to be passed into `MaskDecoder` class.
         sam_mask_decoder_extra_args=None,
         compile_image_encoder: bool = False,
+        # Whether to predict if there is a cell division in the frame
+        pred_div_scores: bool = False,
+        # Whether to use an MLP to predict cell division scores
+        pred_div_scores_mlp: bool = False,
     ):
         super().__init__()
 
@@ -164,6 +168,8 @@ class SAM2Base(torch.nn.Module):
         self.sam_mask_decoder_extra_args = sam_mask_decoder_extra_args
         self.pred_obj_scores = pred_obj_scores
         self.pred_obj_scores_mlp = pred_obj_scores_mlp
+        self.pred_div_scores = pred_div_scores
+        self.pred_div_scores_mlp = pred_div_scores_mlp
         self.fixed_no_obj_ptr = fixed_no_obj_ptr
         self.soft_no_obj_ptr = soft_no_obj_ptr
         if self.fixed_no_obj_ptr:
@@ -235,6 +241,8 @@ class SAM2Base(torch.nn.Module):
             iou_prediction_use_sigmoid=self.iou_prediction_use_sigmoid,
             pred_obj_scores=self.pred_obj_scores,
             pred_obj_scores_mlp=self.pred_obj_scores_mlp,
+            pred_div_scores=self.pred_div_scores,
+            pred_div_scores_mlp=self.pred_div_scores_mlp,
             use_multimask_token_for_obj_ptr=self.use_multimask_token_for_obj_ptr,
             **(self.sam_mask_decoder_extra_args or {}),
         )
@@ -260,7 +268,8 @@ class SAM2Base(torch.nn.Module):
         point_inputs=None,
         mask_inputs=None,
         high_res_features=None,
-        multimask_output=False,
+        is_dividing=None,
+        gt_masks=None,
     ):
         """
         Forward SAM prompt encoders and mask heads.
@@ -277,29 +286,18 @@ class SAM2Base(torch.nn.Module):
         - high_res_features: either 1) None or 2) or a list of length 2 containing
           two feature maps of [B, C, 4*H, 4*W] and [B, C, 2*H, 2*W] shapes respectively,
           which will be used as high-resolution feature maps for SAM decoder.
-        - multimask_output: if it's True, we output 3 candidate masks and their 3
-          corresponding IoU estimates, and if it's False, we output only 1 mask and
-          its corresponding IoU estimate.
+        - is_dividing: Optional tensor indicating which cells are dividing
+        - gt_masks: Optional ground truth masks for training
 
         Outputs:
-        - low_res_multimasks: [B, M, H*4, W*4] shape (where M = 3 if
-          `multimask_output=True` and M = 1 if `multimask_output=False`), the SAM
-          output mask logits (before sigmoid) for the low-resolution masks, with 4x
-          the resolution (1/4 stride) of the input backbone_features.
-        - high_res_multimasks: [B, M, H*16, W*16] shape (where M = 3
-          if `multimask_output=True` and M = 1 if `multimask_output=False`),
-          upsampled from the low-resolution masks, with shape size as the image
-          (stride is 1 pixel).
-        - ious, [B, M] shape, where (where M = 3 if `multimask_output=True` and M = 1
-          if `multimask_output=False`), the estimated IoU of each output mask.
-        - low_res_masks: [B, 1, H*4, W*4] shape, the best mask in `low_res_multimasks`.
-          If `multimask_output=True`, it's the mask with the highest IoU estimate.
-          If `multimask_output=False`, it's the same as `low_res_multimasks`.
-        - high_res_masks: [B, 1, H*16, W*16] shape, the best mask in `high_res_multimasks`.
-          If `multimask_output=True`, it's the mask with the highest IoU estimate.
-          If `multimask_output=False`, it's the same as `high_res_multimasks`.
-        - obj_ptr: [B, C] shape, the object pointer vector for the output mask, extracted
-          based on the output token from the SAM mask decoder.
+        - ious: [B, 1] shape, the estimated IoU of each output mask.
+        - low_res_masks: [B, 1, H*4, W*4] shape.
+        - high_res_masks: [B, 1, H*16, W*16] shape.
+        - obj_ptr: [B, C] shape, the object pointer vector for the output mask.
+        - object_score_logits: [B, 1] shape, the object score logits for the output mask.
+        - div_score_logits: [B, 1] shape, the cell division score logits for the output mask.
+        - post_split_object_score_logits: Score logits for objects after division.
+        - is_dividing: Tensor indicating which cells are dividing pre division.
         """
         B = backbone_features.size(0)
         device = backbone_features.device
@@ -307,17 +305,17 @@ class SAM2Base(torch.nn.Module):
         assert backbone_features.size(2) == self.sam_image_embedding_size
         assert backbone_features.size(3) == self.sam_image_embedding_size
 
-        # a) Handle point prompts
+        # Process point prompts
         if point_inputs is not None:
             sam_point_coords = point_inputs["point_coords"]
             sam_point_labels = point_inputs["point_labels"]
             assert sam_point_coords.size(0) == B and sam_point_labels.size(0) == B
         else:
-            # If no points are provide, pad with an empty point (with label -1)
+            # Create empty point prompt with padding label (-1)
             sam_point_coords = torch.zeros(B, 1, 2, device=device)
             sam_point_labels = -torch.ones(B, 1, dtype=torch.int32, device=device)
 
-        # b) Handle mask prompts
+        # Process mask prompts
         if mask_inputs is not None:
             # If mask_inputs is provided, downsize it into low-res mask input if needed
             # and feed it as a dense mask prompt into the SAM mask encoder
@@ -337,79 +335,86 @@ class SAM2Base(torch.nn.Module):
             # a learned `no_mask_embed` to indicate no mask input in this case).
             sam_mask_prompt = None
 
+        # Encode prompts
         sparse_embeddings, dense_embeddings = self.sam_prompt_encoder(
             points=(sam_point_coords, sam_point_labels),
             boxes=None,
             masks=sam_mask_prompt,
         )
+        
+        # Generate masks through the decoder
         (
-            low_res_multimasks,
+            low_res_masks,
             ious,
             sam_output_tokens,
             object_score_logits,
+            div_score_logits,
+            post_split_object_score_logits,
+            is_dividing,
         ) = self.sam_mask_decoder(
             image_embeddings=backbone_features,
             image_pe=self.sam_prompt_encoder.get_dense_pe(),
             sparse_prompt_embeddings=sparse_embeddings,
             dense_prompt_embeddings=dense_embeddings,
-            multimask_output=multimask_output,
             repeat_image=False,  # the image is already batched
             high_res_features=high_res_features,
+            is_dividing=is_dividing,
+            gt_masks=gt_masks,
         )
-        if self.pred_obj_scores:
-            is_obj_appearing = object_score_logits > 0
 
-            # Mask used for spatial memories is always a *hard* choice between obj and no obj,
-            # consistent with the actual mask prediction
-            low_res_multimasks = torch.where(
-                is_obj_appearing[:, None, None],
-                low_res_multimasks,
+        num_non_dividing_cells = (~is_dividing).sum()
+
+        # Apply object score thresholding for non-dividing cells
+        if self.pred_obj_scores and num_non_dividing_cells > 0:
+            is_obj_appearing = object_score_logits > 0
+            
+            # Apply hard thresholding to low_res_masks based on object scores
+            # Set masks to NO_OBJ_SCORE where object is not appearing
+            low_res_masks[:num_non_dividing_cells] = torch.where(
+                is_obj_appearing[:num_non_dividing_cells, None, None],
+                low_res_masks[:num_non_dividing_cells],
                 NO_OBJ_SCORE,
             )
 
-        # convert masks from possibly bfloat16 (or float16) to float32
-        # (older PyTorch versions before 2.1 don't support `interpolate` on bf16)
-        low_res_multimasks = low_res_multimasks.float()
-        high_res_multimasks = F.interpolate(
-            low_res_multimasks,
+        # Ensure masks are float32 for interpolation compatibility
+        low_res_masks = low_res_masks.float()
+        
+        # Upsample masks to high resolution
+        high_res_masks = F.interpolate(
+            low_res_masks,
             size=(self.image_size, self.image_size),
             mode="bilinear",
             align_corners=False,
         )
 
+        # Extract and process object pointers
         sam_output_token = sam_output_tokens[:, 0]
-        if multimask_output:
-            # take the best mask prediction (with the highest IoU estimation)
-            best_iou_inds = torch.argmax(ious, dim=-1)
-            batch_inds = torch.arange(B, device=device)
-            low_res_masks = low_res_multimasks[batch_inds, best_iou_inds].unsqueeze(1)
-            high_res_masks = high_res_multimasks[batch_inds, best_iou_inds].unsqueeze(1)
-            if sam_output_tokens.size(1) > 1:
-                sam_output_token = sam_output_tokens[batch_inds, best_iou_inds]
-        else:
-            low_res_masks, high_res_masks = low_res_multimasks, high_res_multimasks
-
-        # Extract object pointer from the SAM output token (with occlusion handling)
         obj_ptr = self.obj_ptr_proj(sam_output_token)
-        if self.pred_obj_scores:
-            # Allow *soft* no obj ptr, unlike for masks
+        
+        # Apply object score conditioning to object pointers
+        if self.pred_obj_scores and num_non_dividing_cells > 0:
+            # Calculate object appearance factor (soft or hard threshold)
             if self.soft_no_obj_ptr:
-                lambda_is_obj_appearing = object_score_logits.sigmoid()
+                lambda_is_obj_appearing = object_score_logits[:num_non_dividing_cells].sigmoid()
             else:
-                lambda_is_obj_appearing = is_obj_appearing.float()
+                lambda_is_obj_appearing = is_obj_appearing[:num_non_dividing_cells].float()
 
+            # Apply fixed no-object pointer if configured
             if self.fixed_no_obj_ptr:
-                obj_ptr = lambda_is_obj_appearing * obj_ptr
-            obj_ptr = obj_ptr + (1 - lambda_is_obj_appearing) * self.no_obj_ptr
+                obj_ptr[:num_non_dividing_cells] = lambda_is_obj_appearing * obj_ptr[:num_non_dividing_cells]
+                
+            # Mix in no-object pointer based on object appearance factor
+            obj_ptr[:num_non_dividing_cells] = obj_ptr[:num_non_dividing_cells] + (1 - lambda_is_obj_appearing) * self.no_obj_ptr
 
         return (
-            low_res_multimasks,
-            high_res_multimasks,
             ious,
             low_res_masks,
             high_res_masks,
             obj_ptr,
             object_score_logits,
+            div_score_logits,
+            post_split_object_score_logits,
+            is_dividing,
         )
 
     def _use_mask_as_output(self, backbone_features, high_res_features, mask_inputs):
@@ -503,167 +508,57 @@ class SAM2Base(torch.nn.Module):
         feat_sizes,
         output_dict,
         num_frames,
+        tracking_object_ids,
+        memory_dict,
         track_in_reverse=False,  # tracking in reverse time order (for demo usage)
     ):
-        """Fuse the current frame's visual feature map with previous memory."""
+        """
+        Fuse the current frame's visual feature map with previous memory.
+        
+        Args:
+            frame_idx: Index of the current frame
+            is_init_cond_frame: Whether this is an initial conditioning frame
+            current_vision_feats: List of feature maps from the vision encoder
+            current_vision_pos_embeds: List of positional embeddings
+            feat_sizes: Sizes of the feature maps
+            output_dict: Dictionary containing outputs from previous frames
+            num_frames: Total number of frames
+            tracking_object_ids: IDs of objects being tracked
+            memory_dict: Dictionary containing memory features for each object
+            track_in_reverse: Whether tracking is in reverse time order
+            
+        Returns:
+            Tensor of shape [B, C, H, W] containing the fused features
+        """
         B = current_vision_feats[-1].size(1)  # batch size on this frame
         C = self.hidden_dim
         H, W = feat_sizes[-1]  # top-level (lowest-resolution) feature size
         device = current_vision_feats[-1].device
-        # The case of `self.num_maskmem == 0` below is primarily used for reproducing SAM on images.
-        # In this case, we skip the fusion with any memory.
-        if self.num_maskmem == 0:  # Disable memory and skip fusion
+        
+        # Skip memory fusion for image-only mode
+        if self.num_maskmem == 0:
             pix_feat = current_vision_feats[-1].permute(1, 2, 0).view(B, C, H, W)
             return pix_feat
 
-        num_obj_ptr_tokens = 0
-        tpos_sign_mul = -1 if track_in_reverse else 1
-        # Step 1: condition the visual features of the current frame on previous memories
-        if not is_init_cond_frame:
-            # Retrieve the memories encoded with the maskmem backbone
-            to_cat_memory, to_cat_memory_pos_embed = [], []
-            # Add conditioning frames's output first (all cond frames have t_pos=0 for
-            # when getting temporal positional embedding below)
-            assert len(output_dict["cond_frame_outputs"]) > 0
-            # Select a maximum number of temporally closest cond frames for cross attention
-            cond_outputs = output_dict["cond_frame_outputs"]
-            selected_cond_outputs, unselected_cond_outputs = select_closest_cond_frames(
-                frame_idx, cond_outputs, self.max_cond_frames_in_attn
-            )
-            t_pos_and_prevs = [(0, out) for out in selected_cond_outputs.values()]
-            # Add last (self.num_maskmem - 1) frames before current frame for non-conditioning memory
-            # the earliest one has t_pos=1 and the latest one has t_pos=self.num_maskmem-1
-            # We also allow taking the memory frame non-consecutively (with stride>1), in which case
-            # we take (self.num_maskmem - 2) frames among every stride-th frames plus the last frame.
-            stride = 1 if self.training else self.memory_temporal_stride_for_eval
-            for t_pos in range(1, self.num_maskmem):
-                t_rel = self.num_maskmem - t_pos  # how many frames before current frame
-                if t_rel == 1:
-                    # for t_rel == 1, we take the last frame (regardless of r)
-                    if not track_in_reverse:
-                        # the frame immediately before this frame (i.e. frame_idx - 1)
-                        prev_frame_idx = frame_idx - t_rel
-                    else:
-                        # the frame immediately after this frame (i.e. frame_idx + 1)
-                        prev_frame_idx = frame_idx + t_rel
-                else:
-                    # for t_rel >= 2, we take the memory frame from every r-th frames
-                    if not track_in_reverse:
-                        # first find the nearest frame among every r-th frames before this frame
-                        # for r=1, this would be (frame_idx - 2)
-                        prev_frame_idx = ((frame_idx - 2) // stride) * stride
-                        # then seek further among every r-th frames
-                        prev_frame_idx = prev_frame_idx - (t_rel - 2) * stride
-                    else:
-                        # first find the nearest frame among every r-th frames after this frame
-                        # for r=1, this would be (frame_idx + 2)
-                        prev_frame_idx = -(-(frame_idx + 2) // stride) * stride
-                        # then seek further among every r-th frames
-                        prev_frame_idx = prev_frame_idx + (t_rel - 2) * stride
-                out = output_dict["non_cond_frame_outputs"].get(prev_frame_idx, None)
-                if out is None:
-                    # If an unselected conditioning frame is among the last (self.num_maskmem - 1)
-                    # frames, we still attend to it as if it's a non-conditioning frame.
-                    out = unselected_cond_outputs.get(prev_frame_idx, None)
-                t_pos_and_prevs.append((t_pos, out))
-
-            for t_pos, prev in t_pos_and_prevs:
-                if prev is None:
-                    continue  # skip padding frames
-                # "maskmem_features" might have been offloaded to CPU in demo use cases,
-                # so we load it back to GPU (it's a no-op if it's already on GPU).
-                feats = prev["maskmem_features"].to(device, non_blocking=True)
-                to_cat_memory.append(feats.flatten(2).permute(2, 0, 1))
-                # Spatial positional encoding (it might have been offloaded to CPU in eval)
-                maskmem_enc = prev["maskmem_pos_enc"][-1].to(device)
-                maskmem_enc = maskmem_enc.flatten(2).permute(2, 0, 1)
-                # Temporal positional encoding
-                maskmem_enc = (
-                    maskmem_enc + self.maskmem_tpos_enc[self.num_maskmem - t_pos - 1]
-                )
-                to_cat_memory_pos_embed.append(maskmem_enc)
-
-            # Construct the list of past object pointers
-            if self.use_obj_ptrs_in_encoder:
-                max_obj_ptrs_in_encoder = min(num_frames, self.max_obj_ptrs_in_encoder)
-                # First add those object pointers from selected conditioning frames
-                # (optionally, only include object pointers in the past during evaluation)
-                if not self.training and self.only_obj_ptrs_in_the_past_for_eval:
-                    ptr_cond_outputs = {
-                        t: out
-                        for t, out in selected_cond_outputs.items()
-                        if (t >= frame_idx if track_in_reverse else t <= frame_idx)
-                    }
-                else:
-                    ptr_cond_outputs = selected_cond_outputs
-                pos_and_ptrs = [
-                    # Temporal pos encoding contains how far away each pointer is from current frame
-                    (
-                        (
-                            (frame_idx - t) * tpos_sign_mul
-                            if self.use_signed_tpos_enc_to_obj_ptrs
-                            else abs(frame_idx - t)
-                        ),
-                        out["obj_ptr"],
-                    )
-                    for t, out in ptr_cond_outputs.items()
-                ]
-                # Add up to (max_obj_ptrs_in_encoder - 1) non-conditioning frames before current frame
-                for t_diff in range(1, max_obj_ptrs_in_encoder):
-                    t = frame_idx + t_diff if track_in_reverse else frame_idx - t_diff
-                    if t < 0 or (num_frames is not None and t >= num_frames):
-                        break
-                    out = output_dict["non_cond_frame_outputs"].get(
-                        t, unselected_cond_outputs.get(t, None)
-                    )
-                    if out is not None:
-                        pos_and_ptrs.append((t_diff, out["obj_ptr"]))
-                # If we have at least one object pointer, add them to the across attention
-                if len(pos_and_ptrs) > 0:
-                    pos_list, ptrs_list = zip(*pos_and_ptrs)
-                    # stack object pointers along dim=0 into [ptr_seq_len, B, C] shape
-                    obj_ptrs = torch.stack(ptrs_list, dim=0)
-                    # a temporal positional embedding based on how far each object pointer is from
-                    # the current frame (sine embedding normalized by the max pointer num).
-                    if self.add_tpos_enc_to_obj_ptrs:
-                        t_diff_max = max_obj_ptrs_in_encoder - 1
-                        tpos_dim = C if self.proj_tpos_enc_in_obj_ptrs else self.mem_dim
-                        obj_pos = torch.tensor(pos_list).to(
-                            device=device, non_blocking=True
-                        )
-                        obj_pos = get_1d_sine_pe(obj_pos / t_diff_max, dim=tpos_dim)
-                        obj_pos = self.obj_ptr_tpos_proj(obj_pos)
-                        obj_pos = obj_pos.unsqueeze(1).expand(-1, B, self.mem_dim)
-                    else:
-                        obj_pos = obj_ptrs.new_zeros(len(pos_list), B, self.mem_dim)
-                    if self.mem_dim < C:
-                        # split a pointer into (C // self.mem_dim) tokens for self.mem_dim < C
-                        obj_ptrs = obj_ptrs.reshape(
-                            -1, B, C // self.mem_dim, self.mem_dim
-                        )
-                        obj_ptrs = obj_ptrs.permute(0, 2, 1, 3).flatten(0, 1)
-                        obj_pos = obj_pos.repeat_interleave(C // self.mem_dim, dim=0)
-                    to_cat_memory.append(obj_ptrs)
-                    to_cat_memory_pos_embed.append(obj_pos)
-                    num_obj_ptr_tokens = obj_ptrs.shape[0]
-                else:
-                    num_obj_ptr_tokens = 0
-        else:
-            # for initial conditioning frames, encode them without using any previous memory
+        # Handle initial conditioning frames differently
+        if is_init_cond_frame:
             if self.directly_add_no_mem_embed:
-                # directly add no-mem embedding (instead of using the transformer encoder)
+                # Directly add no-memory embedding to features
                 pix_feat_with_mem = current_vision_feats[-1] + self.no_mem_embed
                 pix_feat_with_mem = pix_feat_with_mem.permute(1, 2, 0).view(B, C, H, W)
                 return pix_feat_with_mem
 
-            # Use a dummy token on the first frame (to avoid empty memory input to tranformer encoder)
-            to_cat_memory = [self.no_mem_embed.expand(1, B, self.mem_dim)]
-            to_cat_memory_pos_embed = [self.no_mem_pos_enc.expand(1, B, self.mem_dim)]
+            # Use dummy tokens for initial frames
+            memory = self.no_mem_embed.expand(1, B, self.mem_dim)
+            memory_pos_embed = self.no_mem_pos_enc.expand(1, B, self.mem_dim)
+            num_obj_ptr_tokens = 0
+        else:
+            # Process memory for non-initial frames
+            memory, memory_pos_embed, num_obj_ptr_tokens = self._prepare_memory_for_attention(
+                B, C, H, W, device, tracking_object_ids, memory_dict, num_frames
+            )
 
-        # Step 2: Concatenate the memories and forward through the transformer encoder
-        memory = torch.cat(to_cat_memory, dim=0)
-        memory_pos_embed = torch.cat(to_cat_memory_pos_embed, dim=0)
-
+        # Apply memory attention to fuse features
         pix_feat_with_mem = self.memory_attention(
             curr=current_vision_feats,
             curr_pos=current_vision_pos_embeds,
@@ -671,9 +566,106 @@ class SAM2Base(torch.nn.Module):
             memory_pos=memory_pos_embed,
             num_obj_ptr_tokens=num_obj_ptr_tokens,
         )
-        # reshape the output (HW)BC => BCHW
+        
+        # Reshape output from (HW)BC to BCHW
         pix_feat_with_mem = pix_feat_with_mem.permute(1, 2, 0).view(B, C, H, W)
         return pix_feat_with_mem
+
+    def _prepare_memory_for_attention(self, B, C, H, W, device, tracking_object_ids, memory_dict, num_frames):
+        """
+        Helper method to prepare memory tensors for attention.
+        
+        Returns:
+            Tuple of (memory, memory_pos_embed, num_obj_ptr_tokens)
+        """
+        # Initialize memory tensors
+        memory = torch.zeros(self.num_maskmem, B, self.mem_dim, H, W, device=device)
+        N = 0  # Actual number of memory frames to use
+        
+        # Initialize object pointer tensors if needed
+        if self.use_obj_ptrs_in_encoder:
+            if self.mem_dim < C:
+                obj_ptrs_mem = torch.zeros(
+                    self.num_maskmem, B, C // self.mem_dim, self.mem_dim, device=device
+                )
+            else:
+                raise NotImplementedError("Memory dimension is not supported for obj ptrs")
+        
+        # Process each tracked object
+        for idx, object_id in enumerate(tracking_object_ids):
+            obj_id = object_id.item()
+            
+            # Get memory features for this object if available
+            if obj_id in memory_dict:
+                mask_mem_features = memory_dict[obj_id]["mask_mem_features"]
+                num_mem_frames = min(mask_mem_features.shape[0], self.num_maskmem)
+                memory[:num_mem_frames, idx] = mask_mem_features[-num_mem_frames:]
+                N = max(N, num_mem_frames)
+            else:
+                num_mem_frames = 0
+            
+            # Fill remaining memory slots with no-object embedding
+            if self.no_obj_embed_spatial is not None:
+                memory[num_mem_frames:, idx] = self.no_obj_embed_spatial[0, :, None, None].expand(
+                    self.num_maskmem - num_mem_frames, self.mem_dim, H, W
+                )
+            
+            # Process object pointers if enabled
+            if self.use_obj_ptrs_in_encoder:
+                if obj_id in memory_dict:
+                    obj_ptrs = memory_dict[obj_id]["obj_ptr"][-num_mem_frames:]
+                    # Split pointer into tokens for mem_dim < C
+                    obj_ptrs = obj_ptrs.reshape(-1, C // self.mem_dim, self.mem_dim)
+                    obj_ptrs_mem[:num_mem_frames, idx] = obj_ptrs
+                
+                # Fill remaining slots with no-object pointer
+                obj_ptrs_mem[num_mem_frames:, idx] = self.no_obj_ptr[None].reshape(
+                    1, C // self.mem_dim, self.mem_dim
+                ).expand(self.num_maskmem - num_mem_frames, C // self.mem_dim, self.mem_dim)
+        
+        # Trim to actual number of memory frames
+        memory = memory[:N]
+        
+        # Reshape memory for attention: [N, B, C, H, W] -> [(N*H*W), B, C]
+        memory = memory.flatten(3).permute(0, 3, 1, 2)
+        memory = memory.reshape(-1, B, self.mem_dim)
+        
+        # Process object pointers if enabled
+        num_obj_ptr_tokens = 0
+        if self.use_obj_ptrs_in_encoder:
+            obj_ptrs_mem = obj_ptrs_mem[:N]
+            obj_ptrs_mem = obj_ptrs_mem.permute(0, 2, 1, 3)
+            obj_ptrs_mem = obj_ptrs_mem.reshape(-1, B, self.mem_dim)
+            memory = torch.cat((memory, obj_ptrs_mem), dim=0)
+            num_obj_ptr_tokens = obj_ptrs_mem.shape[0]
+        
+        # Prepare positional embeddings
+        memory_pos_embed = memory_dict["mask_mem_pos_enc"]
+        memory_pos_embed = memory_pos_embed.flatten(2).permute(2, 0, 1)
+        memory_pos_embed = memory_pos_embed[None].expand(N, H*W, B, self.mem_dim)
+        
+        # Add temporal positional encoding
+        t_pos_indices = torch.arange(N, device=device)
+        memory_pos_embed = memory_pos_embed + self.maskmem_tpos_enc[t_pos_indices].expand(N, H*W, B, self.mem_dim)
+        memory_pos_embed = memory_pos_embed.reshape(-1, B, self.mem_dim)
+        
+        # Add object pointer positional embeddings if needed
+        if self.use_obj_ptrs_in_encoder:
+            max_obj_ptrs_in_encoder = min(num_frames, self.max_obj_ptrs_in_encoder)
+            
+            if self.add_tpos_enc_to_obj_ptrs:
+                t_diff_max = max(max_obj_ptrs_in_encoder - 1, 1)  # Avoid division by zero
+                tpos_dim = C if self.proj_tpos_enc_in_obj_ptrs else self.mem_dim
+                obj_pos = get_1d_sine_pe(t_pos_indices / t_diff_max, dim=tpos_dim)
+                obj_pos = self.obj_ptr_tpos_proj(obj_pos)
+                obj_pos = obj_pos.unsqueeze(1).expand(-1, B, self.mem_dim)
+                obj_pos = obj_pos.repeat_interleave(C // self.mem_dim, dim=0)
+            else:
+                obj_pos = memory_pos_embed.new_zeros(C // self.mem_dim, B, self.mem_dim)
+            
+            memory_pos_embed = torch.cat((memory_pos_embed, obj_pos), dim=0)
+        
+        return memory, memory_pos_embed, num_obj_ptr_tokens
 
     def _encode_new_memory(
         self,
@@ -738,6 +730,10 @@ class SAM2Base(torch.nn.Module):
         num_frames,
         track_in_reverse,
         prev_sam_mask_logits,
+        is_dividing,
+        tracking_object_ids,
+        memory_dict,
+        gt_masks=None,
     ):
         current_out = {"point_inputs": point_inputs, "mask_inputs": mask_inputs}
         # High-resolution feature maps for the SAM head, reshape (HW)BC => BCHW
@@ -766,6 +762,8 @@ class SAM2Base(torch.nn.Module):
                 feat_sizes=feat_sizes[-1:],
                 output_dict=output_dict,
                 num_frames=num_frames,
+                tracking_object_ids=tracking_object_ids,
+                memory_dict=memory_dict,
                 track_in_reverse=track_in_reverse,
             )
             # apply SAM-style segmentation head
@@ -775,13 +773,14 @@ class SAM2Base(torch.nn.Module):
             if prev_sam_mask_logits is not None:
                 assert point_inputs is not None and mask_inputs is None
                 mask_inputs = prev_sam_mask_logits
-            multimask_output = self._use_multimask(is_init_cond_frame, point_inputs)
+
             sam_outputs = self._forward_sam_heads(
                 backbone_features=pix_feat,
                 point_inputs=point_inputs,
                 mask_inputs=mask_inputs,
                 high_res_features=high_res_features,
-                multimask_output=multimask_output,
+                is_dividing=is_dividing,
+                gt_masks=gt_masks,
             )
 
         return current_out, sam_outputs, high_res_features, pix_feat
@@ -792,24 +791,40 @@ class SAM2Base(torch.nn.Module):
         feat_sizes,
         point_inputs,
         run_mem_encoder,
-        high_res_masks,
-        object_score_logits,
         current_out,
     ):
-        if run_mem_encoder and self.num_maskmem > 0:
-            high_res_masks_for_mem_enc = high_res_masks
-            maskmem_features, maskmem_pos_enc = self._encode_new_memory(
-                current_vision_feats=current_vision_feats,
-                feat_sizes=feat_sizes,
-                pred_masks_high_res=high_res_masks_for_mem_enc,
-                object_score_logits=object_score_logits,
-                is_mask_from_pts=(point_inputs is not None),
-            )
-            current_out["maskmem_features"] = maskmem_features
-            current_out["maskmem_pos_enc"] = maskmem_pos_enc
-        else:
-            current_out["maskmem_features"] = None
-            current_out["maskmem_pos_enc"] = None
+        """
+        Encode the current frame's prediction into a memory feature.
+        
+        Args:
+            current_vision_feats: Image features from the backbone
+            feat_sizes: Sizes of the feature maps
+            point_inputs: Point prompts if any
+            run_mem_encoder: Whether to run the memory encoder
+            current_out: Dictionary containing current outputs including masks
+            
+        Returns:
+            Tuple of (maskmem_features, maskmem_pos_enc) or (None, None)
+        """
+        if not run_mem_encoder or self.num_maskmem <= 0:
+            return None, None
+        
+        high_res_masks = current_out["pred_masks_high_res"]
+        object_score_logits = current_out["pred_object_score_logits"]
+        
+        maskmem_features, maskmem_pos_enc = self._encode_new_memory(
+            current_vision_feats=current_vision_feats,
+            feat_sizes=feat_sizes,
+            pred_masks_high_res=high_res_masks,
+            object_score_logits=object_score_logits,
+            is_mask_from_pts=(point_inputs is not None),
+        )
+        
+        # Store the memory features in the output dictionary
+        current_out["maskmem_features"] = maskmem_features
+        current_out["maskmem_pos_enc"] = maskmem_pos_enc
+        
+        return maskmem_features, maskmem_pos_enc
 
     def track_step(
         self,
@@ -866,15 +881,17 @@ class SAM2Base(torch.nn.Module):
 
         # Finally run the memory encoder on the predicted mask to encode
         # it into a new memory feature (that can be used in future frames)
-        self._encode_memory_in_output(
+        maskmem_features, maskmem_pos_enc = self._encode_memory_in_output(
             current_vision_feats,
             feat_sizes,
             point_inputs,
             run_mem_encoder,
-            high_res_masks,
-            object_score_logits,
             current_out,
         )
+
+        if maskmem_features is not None:
+            current_out["maskmem_features"] = maskmem_features
+            current_out["maskmem_pos_enc"] = maskmem_pos_enc
 
         return current_out
 

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -424,7 +424,7 @@ class SAM2Base(torch.nn.Module):
         """
         # Use -10/+10 as logits for neg/pos pixels (very close to 0/1 in prob after sigmoid).
         out_scale, out_bias = 20.0, -10.0  # sigmoid(-10.0)=4.5398e-05
-        mask_inputs_float = mask_inputs.float()
+        mask_inputs_float = mask_inputs.to(torch.float32)
         high_res_masks = mask_inputs_float * out_scale + out_bias
         low_res_masks = F.interpolate(
             high_res_masks,

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -97,6 +97,9 @@ class SAM2Base(torch.nn.Module):
         pred_div_scores: bool = False,
         # Whether to use an MLP to predict cell division scores
         pred_div_scores_mlp: bool = False,
+        pred_iou_thresh: float = 0.7,
+        obj_score_thresh: float = 0.5,
+        div_obj_score_thresh: float = 0.5,
     ):
         super().__init__()
 
@@ -183,6 +186,10 @@ class SAM2Base(torch.nn.Module):
         if no_obj_embed_spatial:
             self.no_obj_embed_spatial = torch.nn.Parameter(torch.zeros(1, self.mem_dim))
             trunc_normal_(self.no_obj_embed_spatial, std=0.02)
+        
+        self.pred_iou_thresh = pred_iou_thresh
+        self.obj_score_thresh = obj_score_thresh
+        self.div_obj_score_thresh = div_obj_score_thresh
 
         self._build_sam_heads()
         self.max_cond_frames_in_attn = max_cond_frames_in_attn
@@ -244,6 +251,9 @@ class SAM2Base(torch.nn.Module):
             pred_div_scores=self.pred_div_scores,
             pred_div_scores_mlp=self.pred_div_scores_mlp,
             use_multimask_token_for_obj_ptr=self.use_multimask_token_for_obj_ptr,
+            pred_iou_thresh=self.pred_iou_thresh,
+            obj_score_thresh=self.obj_score_thresh,
+            div_obj_score_thresh=self.div_obj_score_thresh,
             **(self.sam_mask_decoder_extra_args or {}),
         )
         if self.use_obj_ptrs_in_encoder:

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -641,7 +641,7 @@ class SAM2Base(torch.nn.Module):
         
         # Prepare positional embeddings
         memory_pos_embed = memory_dict["mask_mem_pos_enc"]
-        memory_pos_embed = memory_pos_embed.flatten(2).permute(2, 0, 1)
+        memory_pos_embed = memory_pos_embed[:1].flatten(2).permute(2, 0, 1)
         memory_pos_embed = memory_pos_embed[None].expand(N, H*W, B, self.mem_dim)
         
         # Add temporal positional encoding

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -533,7 +533,7 @@ class SAM2Base(torch.nn.Module):
         device = current_vision_feats[-1].device
         
         # Skip memory fusion for image-only mode
-        if self.num_maskmem == 0:
+        if self.num_maskmem == 0 or len(tracking_object_ids) == 0:
             pix_feat = current_vision_feats[-1].permute(1, 2, 0).view(B, C, H, W)
             return pix_feat
 

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -501,16 +501,13 @@ class SAM2Base(torch.nn.Module):
 
     def _prepare_memory_conditioned_features(
         self,
-        frame_idx,
         is_init_cond_frame,
         current_vision_feats,
         current_vision_pos_embeds,
         feat_sizes,
-        output_dict,
         num_frames,
         tracking_object_ids,
         memory_dict,
-        track_in_reverse=False,  # tracking in reverse time order (for demo usage)
     ):
         """
         Fuse the current frame's visual feature map with previous memory.
@@ -719,16 +716,13 @@ class SAM2Base(torch.nn.Module):
 
     def _track_step(
         self,
-        frame_idx,
         is_init_cond_frame,
         current_vision_feats,
         current_vision_pos_embeds,
         feat_sizes,
         point_inputs,
         mask_inputs,
-        output_dict,
         num_frames,
-        track_in_reverse,
         prev_sam_mask_logits,
         is_dividing,
         tracking_object_ids,
@@ -755,16 +749,13 @@ class SAM2Base(torch.nn.Module):
         else:
             # fused the visual feature with previous memory features in the memory bank
             pix_feat = self._prepare_memory_conditioned_features(
-                frame_idx=frame_idx,
                 is_init_cond_frame=is_init_cond_frame,
                 current_vision_feats=current_vision_feats[-1:],
                 current_vision_pos_embeds=current_vision_pos_embeds[-1:],
                 feat_sizes=feat_sizes[-1:],
-                output_dict=output_dict,
                 num_frames=num_frames,
                 tracking_object_ids=tracking_object_ids,
                 memory_dict=memory_dict,
-                track_in_reverse=track_in_reverse,
             )
             # apply SAM-style segmentation head
             # here we might feed previously predicted low-res SAM mask logits into the SAM mask decoder,

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -930,3 +930,100 @@ class SAM2Base(torch.nn.Module):
         # don't overlap (here sigmoid(-10.0)=4.5398e-05)
         pred_masks = torch.where(keep, pred_masks, torch.clamp(pred_masks, max=-10.0))
         return pred_masks
+
+    def _update_memory_features(
+        self,
+        current_vision_feats,
+        feat_sizes,
+        point_inputs,
+        run_mem_encoder,
+        current_out,
+        memory_dict,
+        tracking_object_ids,
+        frame_idx,
+        mother_ids,
+        prev_tracking_object_ids,
+        daughter_ids_list,
+    ):
+        """Update memory features for temporal tracking."""
+        # Encode current frame predictions into memory features
+        maskmem_features, maskmem_pos_enc = self._encode_memory_in_output(
+            current_vision_feats,
+            feat_sizes,
+            point_inputs,
+            run_mem_encoder,
+            current_out,
+        )
+        
+        if maskmem_features is None or maskmem_pos_enc is None:
+            return
+            
+        # Store position encoding
+        memory_dict["mask_mem_pos_enc"] = maskmem_pos_enc[0]
+        
+        # Update memory features for each tracked object
+        for i, object_id in enumerate(tracking_object_ids):
+            obj_id = object_id.item()
+            
+            if obj_id not in memory_dict:
+                # Initialize memory for new object
+                memory_dict[obj_id] = {
+                    "mask_mem_features": maskmem_features[i:i+1], 
+                    "obj_ptr": current_out["obj_ptr"][i:i+1], 
+                    "frame_idx": [frame_idx]
+                }
+            else:
+                # Update memory for existing object
+                memory_dict[obj_id]["mask_mem_features"] = torch.cat(
+                    (memory_dict[obj_id]["mask_mem_features"], maskmem_features[i:i+1]), 
+                    dim=0
+                )
+                memory_dict[obj_id]["obj_ptr"] = torch.cat(
+                    (memory_dict[obj_id]["obj_ptr"], current_out["obj_ptr"][i:i+1]), 
+                    dim=0
+                )
+                memory_dict[obj_id]["frame_idx"].append(frame_idx)
+        
+        # Handle memory inheritance for daughter cells
+        for mother_id in mother_ids:
+            try:
+                # Find mother cell index
+                mother_id_index = torch.where(prev_tracking_object_ids == mother_id)[0].item()
+                daughter_ids = daughter_ids_list[mother_id_index]
+                
+                # Verify mother cell has memory from previous frame
+                mother_id_item = mother_id.item()
+                if mother_id_item not in memory_dict:
+                    logging.warning(f"Mother ID {mother_id_item} not found in memory dict")
+                    continue
+                    
+                if memory_dict[mother_id_item]["frame_idx"][-1] != frame_idx-1:
+                    logging.warning(f"Mother ID {mother_id_item} last frame is not {frame_idx-1}")
+                    continue
+                
+                # Transfer mother's memory to daughters
+                for daughter_id in daughter_ids:
+                    if daughter_id.item() == 0:  # Skip invalid daughter IDs
+                        continue
+                        
+                    daughter_id_item = daughter_id.item()
+                    if daughter_id_item not in memory_dict:
+                        logging.warning(f"Daughter ID {daughter_id_item} not found in memory dict")
+                        continue
+                        
+                    # Prepend mother's last memory to daughter's memory
+                    memory_dict[daughter_id_item]["mask_mem_features"] = torch.cat(
+                        (memory_dict[mother_id_item]["mask_mem_features"][-1:], 
+                         memory_dict[daughter_id_item]["mask_mem_features"]), 
+                        dim=0
+                    )
+                    memory_dict[daughter_id_item]["obj_ptr"] = torch.cat(
+                        (memory_dict[mother_id_item]["obj_ptr"][-1:], 
+                         memory_dict[daughter_id_item]["obj_ptr"]), 
+                        dim=0
+                    )
+                    memory_dict[daughter_id_item]["frame_idx"].insert(0, frame_idx-1)
+            except Exception as e:
+                logging.error(f"Error handling memory for mother ID {mother_id.item()}: {str(e)}")
+
+        return memory_dict

--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -13,6 +13,7 @@ import torch
 from PIL import Image
 from tqdm import tqdm
 import re
+from pathlib import Path
 
 def get_sdpa_settings():
     if torch.cuda.is_available():
@@ -183,6 +184,10 @@ def load_video_frames(
     Load the video frames from video_path. The frames are resized to image_size as in
     the model and are loaded to GPU if offload_video_to_cpu=False. This is used by the demo.
     """
+
+    if isinstance(video_path, Path):
+        video_path = str(video_path)
+
     is_bytes = isinstance(video_path, bytes)
     is_str = isinstance(video_path, str)
     is_mp4_path = is_str and os.path.splitext(video_path)[-1] in [".mp4", ".MP4"]

--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch
 from PIL import Image
 from tqdm import tqdm
-
+import re
 
 def get_sdpa_settings():
     if torch.cuda.is_available():
@@ -177,6 +177,7 @@ def load_video_frames(
     img_std=(0.229, 0.224, 0.225),
     async_loading_frames=False,
     compute_device=torch.device("cuda"),
+    transforms=None,
 ):
     """
     Load the video frames from video_path. The frames are resized to image_size as in
@@ -189,6 +190,7 @@ def load_video_frames(
         return load_video_frames_from_video_file(
             video_path=video_path,
             image_size=image_size,
+            transforms=transforms,
             offload_video_to_cpu=offload_video_to_cpu,
             img_mean=img_mean,
             img_std=img_std,
@@ -198,6 +200,7 @@ def load_video_frames(
         return load_video_frames_from_jpg_images(
             video_path=video_path,
             image_size=image_size,
+            transforms=transforms,
             offload_video_to_cpu=offload_video_to_cpu,
             img_mean=img_mean,
             img_std=img_std,
@@ -214,6 +217,7 @@ def load_video_frames_from_jpg_images(
     video_path,
     image_size,
     offload_video_to_cpu,
+    transforms,
     img_mean=(0.485, 0.456, 0.406),
     img_std=(0.229, 0.224, 0.225),
     async_loading_frames=False,
@@ -228,7 +232,7 @@ def load_video_frames_from_jpg_images(
     You can load a frame asynchronously by setting `async_loading_frames` to `True`.
     """
     if isinstance(video_path, str) and os.path.isdir(video_path):
-        jpg_folder = video_path
+        img_folder = video_path
     else:
         raise NotImplementedError(
             "Only JPEG frames are supported at this moment. For video files, you may use "
@@ -242,14 +246,14 @@ def load_video_frames_from_jpg_images(
 
     frame_names = [
         p
-        for p in os.listdir(jpg_folder)
-        if os.path.splitext(p)[-1] in [".jpg", ".jpeg", ".JPG", ".JPEG"]
+        for p in os.listdir(img_folder)
+        if os.path.splitext(p)[-1] in [".jpg", ".jpeg", ".JPG", ".JPEG", ".png", ".PNG", ".tiff", ".TIFF", ".tif", ".TIF"]
     ]
-    frame_names.sort(key=lambda p: int(os.path.splitext(p)[0]))
+    frame_names.sort(key=lambda p: int(re.findall(r'\d+', p)[-1]))
     num_frames = len(frame_names)
     if num_frames == 0:
-        raise RuntimeError(f"no images found in {jpg_folder}")
-    img_paths = [os.path.join(jpg_folder, frame_name) for frame_name in frame_names]
+        raise RuntimeError(f"no images found in {img_folder}")
+    img_paths = [os.path.join(img_folder, frame_name) for frame_name in frame_names]
     img_mean = torch.tensor(img_mean, dtype=torch.float32)[:, None, None]
     img_std = torch.tensor(img_std, dtype=torch.float32)[:, None, None]
 
@@ -264,17 +268,21 @@ def load_video_frames_from_jpg_images(
         )
         return lazy_images, lazy_images.video_height, lazy_images.video_width
 
+    image = Image.open(img_paths[0]).convert("RGB")
+    resized_image_size, padding = transforms._set_hw_params(image, image_size)
+
     images = torch.zeros(num_frames, 3, image_size, image_size, dtype=torch.float32)
-    for n, img_path in enumerate(tqdm(img_paths, desc="frame loading (JPEG)")):
-        images[n], video_height, video_width = _load_img_as_tensor(img_path, image_size)
+    for n, img_path in enumerate(tqdm(img_paths, desc="frame loading (image)")):
+
+        image = Image.open(img_path).convert("RGB")
+        video_width, video_height = image.size
+        image = transforms(image)
+        images[n] = image.to(compute_device)
+
     if not offload_video_to_cpu:
         images = images.to(compute_device)
-        img_mean = img_mean.to(compute_device)
-        img_std = img_std.to(compute_device)
-    # normalize by mean and std
-    images -= img_mean
-    images /= img_std
-    return images, video_height, video_width
+
+    return images, video_height, video_width, resized_image_size, padding
 
 
 def load_video_frames_from_video_file(

--- a/training/dataset/sam2_datasets.py
+++ b/training/dataset/sam2_datasets.py
@@ -15,169 +15,99 @@ from torch.utils.data import BatchSampler, DataLoader, Dataset, IterableDataset,
 from torch.utils.data.distributed import DistributedSampler
 
 
-class MixedDataLoader:
-    def __init__(self, dataloaders: List[DataLoader], mixing_prob: torch.FloatTensor):
-        """
-        Args:
-            dataloaders (List[DataLoader]): List of DataLoaders to be mixed.
-            mixing_prob (torch.FloatTensor): Probability of each dataloader to be sampled from
-
-        """
-        assert len(dataloaders) == mixing_prob.shape[0]
-        self.dataloaders = dataloaders
-        self.mixing_prob = mixing_prob
-        # Iterator state
-        self._iter_dls = None
-        self._iter_mixing_prob = None
-        self.random_generator = torch.Generator()
-
-    def __len__(self):
-        return sum([len(d) for d in self.dataloaders])
-
-    def __iter__(self):
-        # Synchronize dataloader seeds
-        self.random_generator.manual_seed(42)
-        self._iter_dls = [iter(loader) for loader in self.dataloaders]
-        self._iter_mixing_prob = self.mixing_prob.clone()
-        return self
-
-    def __next__(self):
-        """
-        Sample a dataloader to sample from based on mixing probabilities. If one of the dataloaders is exhausted, we continue sampling from the other loaders until all are exhausted.
-        """
-        if self._iter_dls is None:
-            raise TypeError(f"{type(self).__name__} object is not an iterator")
-
-        while self._iter_mixing_prob.any():  # at least one D-Loader with non-zero prob.
-            dataset_idx = self._iter_mixing_prob.multinomial(
-                1, generator=self.random_generator
-            ).item()
-            try:
-                item = next(self._iter_dls[dataset_idx])
-                return item
-            except StopIteration:
-                # No more iterations for this dataset, set it's mixing probability to zero and try again.
-                self._iter_mixing_prob[dataset_idx] = 0
-            except Exception as e:
-                # log and raise any other unexpected error.
-                logging.error(e)
-                raise e
-
-        # Exhausted all iterators
-        raise StopIteration
-
-
-class TorchTrainMixedDataset:
+class SingleDataLoader:
     def __init__(
         self,
-        datasets: List[Dataset],
-        batch_sizes: List[int],
+        dataset: Dataset,
+        batch_size: int,
         num_workers: int,
-        shuffle: bool,
-        pin_memory: bool,
-        drop_last: bool,
+        shuffle: bool = True,
+        pin_memory: bool = True,
+        drop_last: bool = True,
         collate_fn: Optional[Callable] = None,
         worker_init_fn: Optional[Callable] = None,
-        phases_per_epoch: int = 1,
-        dataset_prob: Optional[List[float]] = None,
     ) -> None:
         """
+        A simplified dataloader that works with a single dataset.
+        
         Args:
-            datasets (List[Dataset]): List of Datasets to be mixed.
-            batch_sizes (List[int]): Batch sizes for each dataset in the list.
-            num_workers (int): Number of workers per dataloader.
-            shuffle (bool): Whether or not to shuffle data.
-            pin_memory (bool): If True, use pinned memory when loading tensors from disk.
-            drop_last (bool): Whether or not to drop the last batch of data.
-            collate_fn (Callable): Function to merge a list of samples into a mini-batch.
-            worker_init_fn (Callable): Function to init each dataloader worker.
-            phases_per_epoch (int): Number of phases per epoch.
-            dataset_prob (List[float]): Probability of choosing the dataloader to sample from. Should sum to 1.0
+            dataset (Dataset): The dataset to load data from
+            batch_size (int): How many samples per batch to load
+            num_workers (int): How many subprocesses to use for data loading
+            shuffle (bool): Whether to shuffle the data at every epoch
+            pin_memory (bool): If True, the data loader will copy Tensors into CUDA pinned memory
+            drop_last (bool): If True, drop the last incomplete batch
+            collate_fn (callable): Merges a list of samples to form a mini-batch
+            worker_init_fn (callable): If not None, this will be called on each worker subprocess
         """
-
-        self.datasets = datasets
-        self.batch_sizes = batch_sizes
+        self.dataset = dataset
+        self.batch_size = batch_size
         self.num_workers = num_workers
         self.shuffle = shuffle
         self.pin_memory = pin_memory
         self.drop_last = drop_last
         self.collate_fn = collate_fn
         self.worker_init_fn = worker_init_fn
-        assert len(self.datasets) > 0
-        for dataset in self.datasets:
-            assert not isinstance(dataset, IterableDataset), "Not supported"
-            # `RepeatFactorWrapper` requires calling set_epoch first to get its length
-            self._set_dataset_epoch(dataset, 0)
-        self.phases_per_epoch = phases_per_epoch
-        self.chunks = [None] * len(datasets)
-        if dataset_prob is None:
-            # If not provided, assign each dataset a probability proportional to its length.
-            dataset_lens = [
-                (math.floor(len(d) / bs) if drop_last else math.ceil(len(d) / bs))
-                for d, bs in zip(datasets, batch_sizes)
-            ]
-            total_len = sum(dataset_lens)
-            dataset_prob = torch.tensor([d_len / total_len for d_len in dataset_lens])
+        self._iterator = None
+        self._current_epoch = 0
+
+    def __len__(self):
+        if not self.drop_last:
+            return math.ceil(len(self.dataset) / self.batch_size)
+        return len(self.dataset) // self.batch_size
+
+    def __iter__(self):
+        self._iterator = iter(self.get_loader(self._current_epoch))
+        return self
+
+    def __next__(self):
+        if self._iterator is None:
+            raise TypeError(f"{type(self).__name__} object is not an iterator")
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            self._current_epoch += 1
+            raise
+
+    def get_loader(self, epoch: int) -> DataLoader:
+        """
+        Returns a DataLoader for the given epoch.
+        
+        Args:
+            epoch (int): The current epoch number
+        """
+        # Set epoch for dataset if it supports it
+        if hasattr(self.dataset, "set_epoch"):
+            self.dataset.set_epoch(epoch)
+        elif hasattr(self.dataset, "epoch"):
+            self.dataset.epoch = epoch
+
+        # Create sampler based on distributed training status
+        if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+            sampler = torch.utils.data.RandomSampler(self.dataset) if self.shuffle else torch.utils.data.SequentialSampler(self.dataset)
         else:
-            assert len(dataset_prob) == len(datasets)
-            dataset_prob = torch.tensor(dataset_prob)
+            sampler = DistributedSampler(self.dataset, shuffle=self.shuffle)
+            sampler.set_epoch(epoch)
 
-        logging.info(f"Dataset mixing probabilities: {dataset_prob.tolist()}")
-        assert dataset_prob.sum().item() == 1.0, "Probabilities should sum to 1.0"
-        self.dataset_prob = dataset_prob
+        # Create batch sampler
+        batch_sampler = BatchSampler(sampler, self.batch_size, drop_last=self.drop_last)
 
-    def _set_dataset_epoch(self, dataset, epoch: int) -> None:
-        if hasattr(dataset, "epoch"):
-            dataset.epoch = epoch
-        if hasattr(dataset, "set_epoch"):
-            dataset.set_epoch(epoch)
+        # Return dataloader
+        return DataLoader(
+            self.dataset,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            batch_sampler=batch_sampler,
+            collate_fn=self.collate_fn,
+            worker_init_fn=self.worker_init_fn,
+        )
 
-    def get_loader(self, epoch) -> Iterable:
-        dataloaders = []
-        for d_idx, (dataset, batch_size) in enumerate(
-            zip(self.datasets, self.batch_sizes)
-        ):
-            if self.phases_per_epoch > 1:
-                # Major epoch that looops over entire dataset
-                # len(main_epoch) == phases_per_epoch * len(epoch)
-                main_epoch = epoch // self.phases_per_epoch
-
-                # Phase with in the main epoch
-                local_phase = epoch % self.phases_per_epoch
-
-                # Start of new data-epoch or job is resumed after preemtion.
-                if local_phase == 0 or self.chunks[d_idx] is None:
-                    # set seed for dataset epoch
-                    # If using RepeatFactorWrapper, this step currectly re-samples indices before chunking.
-                    self._set_dataset_epoch(dataset, main_epoch)
-
-                    # Separate random generator for subset sampling
-                    g = torch.Generator()
-                    g.manual_seed(main_epoch)
-                    self.chunks[d_idx] = torch.chunk(
-                        torch.randperm(len(dataset), generator=g),
-                        self.phases_per_epoch,
-                    )
-
-                dataset = Subset(dataset, self.chunks[d_idx][local_phase])
-            else:
-                self._set_dataset_epoch(dataset, epoch)
-
-            if not torch.distributed.is_available() or not torch.distributed.is_initialized():
-                sampler = torch.utils.data.RandomSampler(dataset) if self.shuffle else torch.utils.data.SequentialSampler(dataset)
-            else:
-                sampler = DistributedSampler(dataset, shuffle=self.shuffle)
-                sampler.set_epoch(epoch)
-
-            batch_sampler = BatchSampler(sampler, batch_size, drop_last=self.drop_last)
-            dataloaders.append(
-                DataLoader(
-                    dataset,
-                    num_workers=self.num_workers,
-                    pin_memory=self.pin_memory,
-                    batch_sampler=batch_sampler,
-                    collate_fn=self.collate_fn,
-                    worker_init_fn=self.worker_init_fn,
-                )
-            )
-        return MixedDataLoader(dataloaders, self.dataset_prob)
+    def set_epoch(self, epoch: int) -> None:
+        """
+        Manually set the epoch number. This is useful when you want to
+        start from a specific epoch.
+        
+        Args:
+            epoch (int): The epoch number to set
+        """
+        self._current_epoch = epoch

--- a/training/dataset/vos_dataset.py
+++ b/training/dataset/vos_dataset.py
@@ -50,26 +50,14 @@ class VOSDataset(VisionDataset):
 
     def _get_datapoint(self, idx):
 
-        for retry in range(MAX_RETRIES):
-            try:
-                if isinstance(idx, torch.Tensor):
-                    idx = idx.item()
-                # sample a video
-                video, segment_loader = self.video_dataset.get_video(idx)
-                # sample frames and object indices to be used in a datapoint
-                sampled_frms_and_objs = self.sampler.sample(
-                    video, segment_loader, epoch=self.curr_epoch
-                )
-                break  # Succesfully loaded video
-            except Exception as e:
-                if self.training:
-                    logging.warning(
-                        f"Loading failed (id={idx}); Retry {retry} with exception: {e}"
-                    )
-                    idx = random.randrange(0, len(self.video_dataset))
-                else:
-                    # Shouldn't fail to load a val video
-                    raise e
+        if isinstance(idx, torch.Tensor):
+            idx = idx.item()
+        # sample a video
+        video, segment_loader = self.video_dataset.get_video(idx)
+        # sample frames and object indices to be used in a datapoint
+        sampled_frms_and_objs = self.sampler.sample(
+            video, segment_loader, epoch=self.curr_epoch
+        )
 
         datapoint = self.construct(video, sampled_frms_and_objs, segment_loader)
         for transform in self._transforms:
@@ -81,17 +69,19 @@ class VOSDataset(VisionDataset):
         Constructs a VideoDatapoint sample to pass to transforms
         """
         sampled_frames = sampled_frms_and_objs.frames
-        sampled_object_ids = sampled_frms_and_objs.object_ids
+        sampled_object_ids_list = sampled_frms_and_objs.object_ids_list
+        man_track = video.man_track
 
         images = []
         rgb_images = load_images(sampled_frames)
         # Iterate over the sampled frames and store their rgb data and object data (bbox, segment)
-        for frame_idx, frame in enumerate(sampled_frames):
+        for frame_idx, (frame, sampled_object_ids) in enumerate(zip(sampled_frames, sampled_object_ids_list)):
             w, h = rgb_images[frame_idx].size
             images.append(
                 Frame(
                     data=rgb_images[frame_idx],
                     objects=[],
+                    object_ids=sampled_object_ids,
                 )
             )
             # We load the gt segments associated with the current frame
@@ -101,6 +91,7 @@ class VOSDataset(VisionDataset):
                 )
             else:
                 segments = segment_loader.load(frame.frame_idx)
+
             for obj_id in sampled_object_ids:
                 # Extract the segment
                 if obj_id in segments:
@@ -115,26 +106,66 @@ class VOSDataset(VisionDataset):
                         continue
                     segment = torch.zeros(h, w, dtype=torch.uint8)
 
+                # Initialize default values
+                parent_id = 0
+                entering = True
+                daughter_ids = torch.zeros((2), dtype=torch.int32)
+                is_in_next_object_ids_list = True
+
+                if man_track is not None and obj_id > 0:
+                    # Get cell lineage information from man_track
+                    cell_info = man_track[man_track[:,0] == obj_id]
+                    if len(cell_info) > 0:  # Check if cell_info is not empty
+                        cell_info = cell_info[0]
+                        _, start_frame, end_frame, parent_id = cell_info
+                        parent_id = int(parent_id)
+
+                        # Cell is entering if current frame is its start frame
+                        entering = bool(start_frame == frame.frame_idx)
+
+                        # Check if this cell has daughter cells and is currently dividing
+                        if obj_id in man_track[:,-1] and end_frame + 1 == frame.frame_idx:
+                            # Get IDs of daughter cells when division occurs
+                            daughter_ids = torch.tensor(
+                                man_track[man_track[:,-1] == obj_id, 0], 
+                                dtype=torch.int32
+                            )
+                
+                # Determine if this cell should be tracked in the next frame
+                if frame_idx < len(sampled_object_ids_list) - 1:
+                    # Cell is in next frame's object list or has daughter cells
+                    is_in_next_object_ids_list = (
+                        obj_id in sampled_object_ids_list[frame_idx+1] or 
+                        daughter_ids.sum() > 0
+                    )
+
                 images[frame_idx].objects.append(
                     Object(
                         object_id=obj_id,
                         frame_index=frame.frame_idx,
                         segment=segment,
+                        entering=entering,
+                        parent_id=parent_id,
+                        daughter_ids=daughter_ids,
+                        is_in_next_object_ids_list=is_in_next_object_ids_list
                     )
                 )
 
-            images[frame_idx].objects.append(
-                Object(
-                    object_id=-1000,
-                    frame_index=frame.frame_idx,
-                    segment=segments['bkgd_mask'],
+            # Add background mask if available
+            if 'bkgd_mask' in segments:
+                images[frame_idx].objects.append(
+                    Object(
+                        object_id=-1000,
+                        frame_index=frame.frame_idx,
+                        segment=segments['bkgd_mask'],
+                    )
                 )
-            )
             
         return VideoDatapoint(
             frames=images,
             video_id=video.video_id,
             size=(h, w),
+            man_track=man_track,
         )
 
     def __getitem__(self, idx):

--- a/training/dataset/vos_dataset.py
+++ b/training/dataset/vos_dataset.py
@@ -3,9 +3,7 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-
-import logging
-import random
+ 
 from copy import deepcopy
 
 import numpy as np
@@ -20,10 +18,6 @@ from training.dataset.vos_sampler import VOSSampler
 from training.dataset.vos_segment_loader import JSONSegmentLoader
 
 from training.utils.data_utils import Frame, Object, VideoDatapoint
-
-MAX_RETRIES = 100
-
-
 class VOSDataset(VisionDataset):
     def __init__(
         self,
@@ -33,7 +27,6 @@ class VOSDataset(VisionDataset):
         sampler: VOSSampler,
         multiplier: int,
         always_target=True,
-        target_segments_available=True,
     ):
         self._transforms = transforms
         self.training = training
@@ -46,7 +39,6 @@ class VOSDataset(VisionDataset):
 
         self.curr_epoch = 0  # Used in case data loader behavior changes across epochs
         self.always_target = always_target
-        self.target_segments_available = target_segments_available
 
     def _get_datapoint(self, idx):
 

--- a/training/dataset/vos_raw_dataset.py
+++ b/training/dataset/vos_raw_dataset.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import List, Optional
 import re
 import torch
+import numpy as np
 
 from iopath.common.file_io import g_pathmgr
 
@@ -39,6 +40,7 @@ class VOSVideo:
     video_name: str
     video_id: int
     frames: List[VOSFrame]
+    man_track: Optional[str] = None
 
     def __len__(self):
         return len(self.frames)
@@ -100,7 +102,6 @@ class CTCRawDataset(VOSRawDataset):
         else:
             return len(self.video_names)
     def get_video(self, idx):
-
         if self.num_frames == 1:
             # SEGMENTATION mode
             video_name, frame_path = self.frame_index[idx]
@@ -117,7 +118,8 @@ class CTCRawDataset(VOSRawDataset):
             for fpath in all_frames[::self.sample_rate]:
                 fid = int(re.findall(r'\d+', fpath.stem)[0])
                 frames.append(VOSFrame(fid, image_path=fpath))
-            video = VOSVideo(video_name, int(video_name), frames)
+            man_track = np.loadtxt(self.train_dir / (video_name + "_GT") / "TRA" / "man_track.txt",dtype=np.int16)
+            video = VOSVideo(video_name, int(video_name), frames, man_track)
 
         video_mask_root = self.train_dir / (video_name + "_GT") / "TRA"
         segment_loader = CTCSegmentLoader(video_mask_root)

--- a/training/dataset/vos_raw_dataset.py
+++ b/training/dataset/vos_raw_dataset.py
@@ -63,12 +63,10 @@ class CTCRawDataset(VOSRawDataset):
                  sample_rate=1):
         
         self.train_dir = Path(train_dir)
-
         self.img_folders = list(self.train_dir.glob("[0-9][0-9]"))
-
+        self.num_frames = num_frames
         self.truncate_video = truncate_video
         self.sample_rate = sample_rate
-        self.num_frames = num_frames
 
         # Read the subset defined in file_list_txt
         if file_list_txt is not None:
@@ -89,38 +87,57 @@ class CTCRawDataset(VOSRawDataset):
             [video_name for video_name in subset if video_name not in excluded_files]
         )
 
-        if self.num_frames == 1:
-            self.frame_index = []
-            for video_name in self.video_names:
-                all_frames = sorted((self.train_dir / video_name).glob("*.tif"))
-                for fpath in all_frames[::self.sample_rate]:
-                    self.frame_index.append((video_name, fpath))
+        # Build index of (video_name, start_frame) pairs
+        self.frame_index = []
+        for video_name in self.video_names:
+            # For initialization, we need all frames to know how many starting points we have
+            all_frames = self.get_all_frames(video_name)
+            
+            # For each possible start frame that allows num_frames sequence
+            max_start_idx = len(all_frames) - self.num_frames + 1 if self.num_frames > 1 else len(all_frames)
+            for i in range(0, max_start_idx):
+                self.frame_index.append((video_name, i))
 
     def __len__(self):
-        if self.num_frames == 1:
-            return len(self.frame_index)
-        else:
-            return len(self.video_names)
-    def get_video(self, idx):
-        if self.num_frames == 1:
-            # SEGMENTATION mode
-            video_name, frame_path = self.frame_index[idx]
-            fid = int(re.findall(r'\d+', frame_path.stem)[0])
-            frame = VOSFrame(fid, image_path=frame_path)
-            video = VOSVideo(video_name, int(video_name), [frame])
-        else:
-            # TRACKING mode
-            video_name = self.video_names[idx]
-            all_frames = sorted((self.train_dir / video_name).glob("*.tif"))
-            if self.truncate_video > 0:
-                all_frames = all_frames[:self.truncate_video]
-            frames = []
-            for fpath in all_frames[::self.sample_rate]:
-                fid = int(re.findall(r'\d+', fpath.stem)[0])
-                frames.append(VOSFrame(fid, image_path=fpath))
-            man_track = np.loadtxt(self.train_dir / (video_name + "_GT") / "TRA" / "man_track.txt",dtype=np.int16)
-            video = VOSVideo(video_name, int(video_name), frames, man_track)
+        return len(self.frame_index)
 
+    def get_all_frames(self, video_name):
+        """Get a sampled subset of frames from a video.
+        Args:
+            video_name: Name of the video
+            start_idx: Starting frame index in the sampled sequence
+        """
+        all_frames = sorted((self.train_dir / video_name).glob("*.tif"))
+        # Apply sampling first since it reduces video size
+        all_frames = all_frames[::self.sample_rate]
+        # Then truncate if needed
+        if self.truncate_video > 0:
+            all_frames = all_frames[:self.truncate_video]            
+                        
+        return all_frames
+
+    def get_video(self, idx):
+        """Get a video starting from the specified frame index"""
+        video_name, start_idx = self.frame_index[idx]
+        
+        # Get just the frames we need
+        all_frames = self.get_all_frames(video_name)
+        selected_frames = all_frames[start_idx:start_idx + self.num_frames]
+        
+        # Create frames list
+        frames = []
+        for fpath in selected_frames:
+            fid = int(re.findall(r'\d+', fpath.stem)[0])
+            frames.append(VOSFrame(fid, image_path=fpath))
+            
+        # Load man_track if available
+        try:
+            man_track = np.loadtxt(self.train_dir / (video_name + "_GT") / "TRA" / "man_track.txt", dtype=np.int16)
+        except:
+            man_track = None
+            
+        video = VOSVideo(video_name, int(video_name), frames, man_track)
+        
         video_mask_root = self.train_dir / (video_name + "_GT") / "TRA"
         segment_loader = CTCSegmentLoader(video_mask_root)
 

--- a/training/dataset/vos_sampler.py
+++ b/training/dataset/vos_sampler.py
@@ -28,94 +28,92 @@ class VOSSampler:
         raise NotImplementedError()
 
 
-class RandomUniformSampler(VOSSampler):
+class FrameIndexSampler(VOSSampler):
     """
-    VOS Sampler for training: sampling random frames and objects
+    Sampler that handles object selection for frames.
+    Frame selection is handled by the DataLoader's sampler using the dataset's frame_index.
+    For training: randomly samples up to max_num_objects
+    For validation: takes first max_num_objects objects
     """
     def __init__(
         self,
-        num_frames,
         max_num_objects,
         max_num_bkgd_objects,
+        is_training,
         num_frames_track_lost_objects=1,
     ):
-        self.num_frames = num_frames
+        super().__init__(sort_frames=not is_training)  # For val, we want sorted frames
         self.max_num_objects = max_num_objects
         self.max_num_bkgd_objects = max_num_bkgd_objects
-
-        if num_frames == 1:
-            self.num_frames_track_lost_objects = 0
-        else:
-            self.num_frames_track_lost_objects = num_frames_track_lost_objects
+        self.is_training = is_training
+        self.num_frames_track_lost_objects = num_frames_track_lost_objects
 
     def sample(self, video, segment_loader, epoch=None):
         """
-        Sample random frames and objects from a video
-
-        Args:
-            video: The video (VOSVideo) to sample from
-            segment_loader: The segment loader (CTCSegmentLoader) to load segments from
-            epoch: The epoch number
-
-        Returns:
-            SampledFramesAndObjects: The sampled frames and objects
+        Handle object selection for the provided frames.
+        Frames are already selected by the DataLoader's sampler using dataset's frame_index.
+        For training: randomly samples up to max_num_objects
+        For validation: takes first max_num_objects objects
         """
+        frames = video.frames
 
-        for retry in range(MAX_RETRIES):
-            if len(video.frames) < self.num_frames:
-                raise Exception(
-                    f"Cannot sample {self.num_frames} frames from video {video.video_name} as it only has {len(video.frames)} annotated frames."
-                )
-            start = random.randrange(0, len(video.frames) - self.num_frames + 1)
-            frames = [video.frames[start + step] for step in range(self.num_frames)]
+        # Get first frame object ids
+        visible_object_ids = []
+        loaded_segms = segment_loader.load(frames[0].frame_idx)
+        if isinstance(loaded_segms, LazySegments):
+            visible_object_ids = list(loaded_segms.keys())
+        else:
+            for object_id, segment in segment_loader.load(
+                frames[0].frame_idx
+            ).items():
+                if segment.sum() and object_id != 'bkgd_mask':
+                    visible_object_ids.append(object_id)
 
-            # Get first frame object ids
-            visible_object_ids = []
-            loaded_segms = segment_loader.load(frames[0].frame_idx)
-            if isinstance(loaded_segms, LazySegments):
-                # LazySegments for SA1BRawDataset
-                visible_object_ids = list(loaded_segms.keys())
-            else:
-                for object_id, segment in segment_loader.load(
-                    frames[0].frame_idx
-                ).items():
-                    if segment.sum() and object_id != 'bkgd_mask':
-                        visible_object_ids.append(object_id)
-
+        # Sample objects based on mode
+        if self.is_training:
+            # Random sample for training
             object_ids = sorted(random.sample(
                 visible_object_ids,
                 min(len(visible_object_ids), self.max_num_objects),
             ))
+        else:
+            # Take first N objects for validation
+            object_ids = sorted(visible_object_ids)[:self.max_num_objects]
 
-            object_ids_list = [object_ids]
-            object_ids_dict = {0: object_ids}
+        object_ids_list = [object_ids]
+        object_ids_dict = {0: object_ids}
 
-            if video.man_track is not None:
-                for i, frame in enumerate(frames):
-                    if i == 0:
-                        continue
-                    
-                    # Get all object ids in the current frame
-                    object_ids_dict[i] = []
-                    input_object_ids = []
-                    
-                    for object_id, segment in segment_loader.load(frame.frame_idx).items():
-                        if isinstance(object_id, int):
-                            parent_id = video.man_track[video.man_track[:, 0] == object_id, -1]
-                            if any([object_id in object_ids_dict[j] for j in range(i)]) or any([parent_id in object_ids_dict[j] for j in range(i)]):
-                                input_object_ids.append(object_id)
-                                object_ids_dict[i].append(object_id)
-                    
-                    # Include objects from previous frames within tracking window
-                    for j in range(i-self.num_frames_track_lost_objects, i):
-                        if j >= 0:  # Ensure we don't access negative indices
-                            input_object_ids.extend(object_ids_dict[j])
-                    
-                    # Remove duplicates and sort
-                    input_object_ids = sorted(list(set(input_object_ids)))
-                    object_ids_list.append(input_object_ids)
+        # Handle object tracking if needed
+        if video.man_track is not None and len(frames) > 1:
+            for i, frame in enumerate(frames):
+                if i == 0:
+                    continue
+                
+                # Get all object ids in the current frame
+                object_ids_dict[i] = []
+                input_object_ids = []
+                
+                for object_id, segment in segment_loader.load(frame.frame_idx).items():
+                    if isinstance(object_id, int):
+                        parent_id = video.man_track[video.man_track[:, 0] == object_id, -1]
+                        if any([object_id in object_ids_dict[j] for j in range(i)]) or any([parent_id in object_ids_dict[j] for j in range(i)]):
+                            input_object_ids.append(object_id)
+                            object_ids_dict[i].append(object_id)
+                
+                # Include objects from previous frames within tracking window
+                for j in range(i-self.num_frames_track_lost_objects, i):
+                    if j >= 0:  # Ensure we don't access negative indices
+                        input_object_ids.extend(object_ids_dict[j])
+                
+                # Remove duplicates and sort
+                input_object_ids = sorted(list(set(input_object_ids)))
+                object_ids_list.append(input_object_ids)
+        else:
+            # If no tracking or single frame, use same objects for all frames
+            object_ids_list.extend([object_ids] * (len(frames) - 1))
 
-            # Calculate how many background points to add
+        # Add background points for training
+        if self.is_training:
             max_num_bkgd_points = min(
                 max(0, self.max_num_objects - len(object_ids_list[0])), 
                 self.max_num_bkgd_objects
@@ -124,39 +122,10 @@ class RandomUniformSampler(VOSSampler):
             num_bkgd_points = random.randint(min_num_bkgd_points, max_num_bkgd_points)
 
             # Generate background object IDs using negative integers
-            bkgd_object_ids = list(range(-1, -1 - num_bkgd_points, -1))  # e.g. [-1, -2, -3, ...]
+            bkgd_object_ids = list(range(-1, -1 - num_bkgd_points, -1))
 
             # Add background objects to frames within tracking window
             for j in range(0, min(len(object_ids_list), self.num_frames_track_lost_objects + 1)):
                 object_ids_list[j] = object_ids_list[j] + bkgd_object_ids
 
-            return SampledFramesAndObjects(frames=frames, object_ids_list=object_ids_list)
-
-        raise Exception("Exceeded MAX_RETRIES in RandomUniformSampler")
-
-
-class EvalSampler(VOSSampler):
-    """
-    VOS Sampler for evaluation: sampling all the frames and all the objects in a video
-    """
-
-    def __init__(
-        self,
-    ):
-        super().__init__()
-
-    def sample(self, video, segment_loader, epoch=None):
-        """
-        Sampling all the frames and all the objects
-        """
-        if self.sort_frames:
-            # ordered by frame id
-            frames = sorted(video.frames, key=lambda x: x.frame_idx)
-        else:
-            # use the original order
-            frames = video.frames
-        object_ids = segment_loader.load(frames[0].frame_idx).keys()
-        if len(object_ids) == 0:
-            raise Exception("First frame of the video has no objects")
-
-        return SampledFramesAndObjects(frames=frames, object_ids=object_ids)
+        return SampledFramesAndObjects(frames=frames, object_ids_list=object_ids_list)

--- a/training/dataset/vos_sampler.py
+++ b/training/dataset/vos_sampler.py
@@ -125,7 +125,8 @@ class RandomUniformSampler(VOSSampler):
                 max(0, self.max_num_objects - len(object_ids_list[0])), 
                 self.max_num_bkgd_objects
             )
-            num_bkgd_points = random.randint(0, max_num_bkgd_points)
+            min_num_bkgd_points = int(len(object_ids_list[0]) == 0)
+            num_bkgd_points = random.randint(min_num_bkgd_points, max_num_bkgd_points)
 
             # Generate background object IDs using negative integers
             bkgd_object_ids = list(range(-1, -1 - num_bkgd_points, -1))  # e.g. [-1, -2, -3, ...]

--- a/training/dataset/vos_sampler.py
+++ b/training/dataset/vos_sampler.py
@@ -113,19 +113,18 @@ class FrameIndexSampler(VOSSampler):
             object_ids_list.extend([object_ids] * (len(frames) - 1))
 
         # Add background points for training
-        if self.is_training:
-            max_num_bkgd_points = min(
-                max(0, self.max_num_objects - len(object_ids_list[0])), 
-                self.max_num_bkgd_objects
-            )
-            min_num_bkgd_points = int(len(object_ids_list[0]) == 0)
-            num_bkgd_points = random.randint(min_num_bkgd_points, max_num_bkgd_points)
+        max_num_bkgd_points = min(
+            max(0, self.max_num_objects - len(object_ids_list[0])), 
+            self.max_num_bkgd_objects
+        )
+        min_num_bkgd_points = int(len(object_ids_list[0]) == 0)
+        num_bkgd_points = random.randint(min_num_bkgd_points, max_num_bkgd_points)
 
-            # Generate background object IDs using negative integers
-            bkgd_object_ids = list(range(-1, -1 - num_bkgd_points, -1))
+        # Generate background object IDs using negative integers
+        bkgd_object_ids = list(range(-1, -1 - num_bkgd_points, -1))
 
-            # Add background objects to frames within tracking window
-            for j in range(0, min(len(object_ids_list), self.num_frames_track_lost_objects + 1)):
-                object_ids_list[j] = object_ids_list[j] + bkgd_object_ids
+        # Add background objects to frames within tracking window
+        for j in range(0, min(len(object_ids_list), self.num_frames_track_lost_objects + 1)):
+            object_ids_list[j] = object_ids_list[j] + bkgd_object_ids
 
         return SampledFramesAndObjects(frames=frames, object_ids_list=object_ids_list)

--- a/training/dataset/vos_sampler.py
+++ b/training/dataset/vos_sampler.py
@@ -106,8 +106,10 @@ class RandomUniformSampler(VOSSampler):
                     
                     for object_id, segment in segment_loader.load(frame.frame_idx).items():
                         if isinstance(object_id, int):
-                            input_object_ids.append(object_id)
-                            object_ids_dict[i].append(object_id)
+                            parent_id = video.man_track[video.man_track[:, 0] == object_id, -1]
+                            if any([object_id in object_ids_dict[j] for j in range(i)]) or any([parent_id in object_ids_dict[j] for j in range(i)]):
+                                input_object_ids.append(object_id)
+                                object_ids_dict[i].append(object_id)
                     
                     # Include objects from previous frames within tracking window
                     for j in range(i-self.num_frames_track_lost_objects, i):

--- a/training/dataset/vos_sampler.py
+++ b/training/dataset/vos_sampler.py
@@ -37,13 +37,11 @@ class RandomUniformSampler(VOSSampler):
         num_frames,
         max_num_objects,
         max_num_bkgd_objects,
-        reverse_time_prob=0.0,
         num_frames_track_lost_objects=1,
     ):
         self.num_frames = num_frames
         self.max_num_objects = max_num_objects
         self.max_num_bkgd_objects = max_num_bkgd_objects
-        self.reverse_time_prob = reverse_time_prob
 
         if num_frames == 1:
             self.num_frames_track_lost_objects = 0
@@ -70,9 +68,6 @@ class RandomUniformSampler(VOSSampler):
                 )
             start = random.randrange(0, len(video.frames) - self.num_frames + 1)
             frames = [video.frames[start + step] for step in range(self.num_frames)]
-            if random.uniform(0, 1) < self.reverse_time_prob:
-                # Reverse time
-                frames = frames[::-1]
 
             # Get first frame object ids
             visible_object_ids = []

--- a/training/loss_fns.py
+++ b/training/loss_fns.py
@@ -14,10 +14,7 @@ import torch.nn.functional as F
 
 from training.trainer import CORE_LOSS_KEY
 
-from training.utils.distributed import get_world_size, is_dist_avail_and_initialized
-
-
-def dice_loss(inputs, targets, num_objects, loss_on_multimask=False):
+def dice_loss(inputs, targets, num_objects):
     """
     Compute the DICE loss, similar to generalized IOU for masks
     Args:
@@ -27,25 +24,15 @@ def dice_loss(inputs, targets, num_objects, loss_on_multimask=False):
                  classification label for each element in inputs
                 (0 for the negative class and 1 for the positive class).
         num_objects: Number of objects in the batch
-        loss_on_multimask: True if multimask prediction is enabled
     Returns:
         Dice loss tensor
     """
-    inputs = inputs.sigmoid()
-    if loss_on_multimask:
-        # inputs and targets are [N, M, H, W] where M corresponds to multiple predicted masks
-        assert inputs.dim() == 4 and targets.dim() == 4
-        # flatten spatial dimension while keeping multimask channel dimension
-        inputs = inputs.flatten(2)
-        targets = targets.flatten(2)
-        numerator = 2 * (inputs * targets).sum(-1)
-    else:
-        inputs = inputs.flatten(1)
-        numerator = 2 * (inputs * targets).sum(1)
+    inputs = inputs.sigmoid().flatten(1)
+    targets = targets.flatten(1)
+    numerator = 2 * (inputs * targets).sum(1)
     denominator = inputs.sum(-1) + targets.sum(-1)
     loss = 1 - (numerator + 1) / (denominator + 1)
-    if loss_on_multimask:
-        return loss / num_objects
+
     return loss.sum() / num_objects
 
 
@@ -55,7 +42,6 @@ def sigmoid_focal_loss(
     num_objects,
     alpha: float = 0.25,
     gamma: float = 2,
-    loss_on_multimask=False,
 ):
     """
     Loss used in RetinaNet for dense detection: https://arxiv.org/abs/1708.02002.
@@ -70,7 +56,6 @@ def sigmoid_focal_loss(
                 positive vs negative examples. Default = -1 (no weighting).
         gamma: Exponent of the modulating factor (1 - p_t) to
                balance easy vs hard examples.
-        loss_on_multimask: True if multimask prediction is enabled
     Returns:
         focal loss tensor
     """
@@ -83,15 +68,11 @@ def sigmoid_focal_loss(
         alpha_t = alpha * targets + (1 - alpha) * (1 - targets)
         loss = alpha_t * loss
 
-    if loss_on_multimask:
-        # loss is [N, M, H, W] where M corresponds to multiple predicted masks
-        assert loss.dim() == 4
-        return loss.flatten(2).mean(-1) / num_objects  # average over spatial dims
     return loss.mean(1).sum() / num_objects
 
 
 def iou_loss(
-    inputs, targets, pred_ious, num_objects, loss_on_multimask=False, use_l1_loss=False
+    inputs, targets, pred_ious, num_objects, use_l1_loss=False
 ):
     """
     Args:
@@ -102,7 +83,6 @@ def iou_loss(
                 (0 for the negative class and 1 for the positive class).
         pred_ious: A float tensor containing the predicted IoUs scores per mask
         num_objects: Number of objects in the batch
-        loss_on_multimask: True if multimask prediction is enabled
         use_l1_loss: Whether to use L1 loss is used instead of MSE loss
     Returns:
         IoU loss tensor
@@ -118,8 +98,6 @@ def iou_loss(
         loss = F.l1_loss(pred_ious, actual_ious, reduction="none")
     else:
         loss = F.mse_loss(pred_ious, actual_ious, reduction="none")
-    if loss_on_multimask:
-        return loss / num_objects
     return loss.sum() / num_objects
 
 
@@ -164,24 +142,18 @@ class MultiStepMultiMasksAndIous(nn.Module):
         self.iou_use_l1_loss = iou_use_l1_loss
         self.pred_obj_scores = pred_obj_scores
 
-    def forward(self, outs_batch: List[Dict], targets_batch: torch.Tensor):
+    def forward(self, outs_batch: List[Dict], targets_batch: torch.Tensor, target_divide_batch: torch.Tensor):
         assert len(outs_batch) == len(targets_batch)
-        num_objects = torch.tensor(
-            (targets_batch.shape[1]), device=targets_batch.device, dtype=torch.float
-        )  # Number of objects is fixed within a batch
-        if is_dist_avail_and_initialized():
-            torch.distributed.all_reduce(num_objects)
-        num_objects = torch.clamp(num_objects / get_world_size(), min=1).item()
 
         losses = defaultdict(int)
-        for outs, targets in zip(outs_batch, targets_batch):
-            cur_losses = self._forward(outs, targets, num_objects)
+        for outs, targets, target_divide in zip(outs_batch, targets_batch, target_divide_batch):
+            cur_losses = self._forward(outs, targets, target_divide)
             for k, v in cur_losses.items():
                 losses[k] += v
 
         return losses
 
-    def _forward(self, outputs: Dict, targets: torch.Tensor, num_objects):
+    def _forward(self, outputs: Dict, targets: torch.Tensor, target_divide: torch.Tensor):
         """
         Compute the losses related to the masks: the focal loss and the dice loss.
         and also the MAE or MSE loss between predicted IoUs and actual IoUs.
@@ -197,106 +169,94 @@ class MultiStepMultiMasksAndIous(nn.Module):
 
         target_masks = targets.unsqueeze(1).float()
         assert target_masks.dim() == 4  # [N, 1, H, W]
-        src_masks_list = outputs["multistep_pred_multimasks_high_res"]
+        src_masks_list = outputs["multistep_pred_masks_high_res"]
         ious_list = outputs["multistep_pred_ious"]
         object_score_logits_list = outputs["multistep_object_score_logits"]
+        div_score_logits_list = outputs["multistep_div_score_logits"]
         is_point_used_list = outputs["multistep_is_point_used"]
+
+        pre_div_target_obj_list = outputs["pre_div_target_obj"]
+        post_div_target_obj_list = outputs["post_div_target_obj"]
 
         assert len(src_masks_list) == len(ious_list)
         assert len(object_score_logits_list) == len(ious_list)
+        assert len(div_score_logits_list) == len(ious_list)
 
         # accumulate the loss over prediction steps
-        losses = {"loss_mask": 0, "loss_dice": 0, "loss_iou": 0, "loss_class": 0}
-        for src_masks, ious, object_score_logits, is_point_used in zip(src_masks_list, ious_list, object_score_logits_list, is_point_used_list):
-            
+        losses = {"loss_mask": 0, "loss_dice": 0, "loss_iou": 0, "loss_div": 0, "loss_class": 0}
+        for src_masks, ious, object_score_logits, div_score_logits, is_point_used, pre_div_target_obj, post_div_target_obj in zip(src_masks_list, ious_list, object_score_logits_list, div_score_logits_list, is_point_used_list, pre_div_target_obj_list, post_div_target_obj_list):
             target_masks_used = target_masks[is_point_used]
             assert len(target_masks_used) == len(src_masks)
 
+            num_objects = torch.tensor(max(1, src_masks.shape[0]), device=src_masks.device, dtype=torch.float)
+
             self._update_losses(
-                losses, src_masks, target_masks_used, ious, num_objects, object_score_logits
+                losses, src_masks, target_masks_used, ious, num_objects, object_score_logits, div_score_logits, pre_div_target_obj, post_div_target_obj, target_divide
             )
         losses[CORE_LOSS_KEY] = self.reduce_loss(losses)
         return losses
 
     def _update_losses(
-        self, losses, src_masks, target_masks, ious, num_objects, object_score_logits
+        self, losses, src_masks, target_masks, ious, num_objects, object_score_logits, div_score_logits, pre_div_target_obj, post_div_target_obj, target_divide
     ):
         target_masks = target_masks.expand_as(src_masks)
+
         # get focal, dice and iou loss on all output masks in a prediction step
-        loss_multimask = sigmoid_focal_loss(
+        loss_mask = sigmoid_focal_loss(
             src_masks,
             target_masks,
             num_objects,
             alpha=self.focal_alpha,
             gamma=self.focal_gamma,
-            loss_on_multimask=True,
         )
-        loss_multidice = dice_loss(
-            src_masks, target_masks, num_objects, loss_on_multimask=True
+        loss_dice = dice_loss(
+            src_masks, target_masks, num_objects
         )
         if not self.pred_obj_scores:
             loss_class = torch.tensor(
-                0.0, dtype=loss_multimask.dtype, device=loss_multimask.device
-            )
-            target_obj = torch.ones(
-                loss_multimask.shape[0],
-                1,
-                dtype=loss_multimask.dtype,
-                device=loss_multimask.device,
+                0.0, dtype=loss_mask.dtype, device=loss_mask.device
             )
         else:
-            target_obj = torch.any((target_masks[:, 0] > 0).flatten(1), dim=-1)[
-                ..., None
-            ].float()
             loss_class = sigmoid_focal_loss(
                 object_score_logits,
-                target_obj,
+                pre_div_target_obj,
                 num_objects,
                 alpha=self.focal_alpha_obj_score,
                 gamma=self.focal_gamma_obj_score,
             )
 
-        loss_multiiou = iou_loss(
+
+        num_dividing_objects = target_divide.sum()
+        if num_dividing_objects > 0:
+            loss_div = sigmoid_focal_loss(
+                div_score_logits,
+                target_divide[:,None].to(torch.float),
+                num_dividing_objects,
+                alpha=self.focal_alpha_obj_score,
+                gamma=self.focal_gamma_obj_score,
+            )
+        else:
+            loss_div = torch.zeros_like(div_score_logits)
+
+        loss_iou = iou_loss(
             src_masks,
             target_masks,
             ious,
             num_objects,
-            loss_on_multimask=True,
             use_l1_loss=self.iou_use_l1_loss,
         )
-        assert loss_multimask.dim() == 2
-        assert loss_multidice.dim() == 2
-        assert loss_multiiou.dim() == 2
-        if loss_multimask.size(1) > 1:
-            # take the mask indices with the smallest focal + dice loss for back propagation
-            loss_combo = (
-                loss_multimask * self.weight_dict["loss_mask"]
-                + loss_multidice * self.weight_dict["loss_dice"]
-            )
-            best_loss_inds = torch.argmin(loss_combo, dim=-1)
-            batch_inds = torch.arange(loss_combo.size(0), device=loss_combo.device)
-            loss_mask = loss_multimask[batch_inds, best_loss_inds].unsqueeze(1)
-            loss_dice = loss_multidice[batch_inds, best_loss_inds].unsqueeze(1)
-            # calculate the iou prediction and slot losses only in the index
-            # with the minimum loss for each mask (to be consistent w/ SAM)
-            if self.supervise_all_iou:
-                loss_iou = loss_multiiou.mean(dim=-1).unsqueeze(1)
-            else:
-                loss_iou = loss_multiiou[batch_inds, best_loss_inds].unsqueeze(1)
-        else:
-            loss_mask = loss_multimask
-            loss_dice = loss_multidice
-            loss_iou = loss_multiiou
 
         # backprop focal, dice and iou loss only if obj present
-        loss_mask = loss_mask * target_obj
-        loss_dice = loss_dice * target_obj
-        loss_iou = loss_iou * target_obj
+        loss_mask = loss_mask * post_div_target_obj
+        loss_dice = loss_dice * post_div_target_obj
+        loss_iou = loss_iou * post_div_target_obj
+        loss_div = loss_div * pre_div_target_obj
 
         # sum over batch dimension (note that the losses are already divided by num_objects)
         losses["loss_mask"] += loss_mask.sum()
         losses["loss_dice"] += loss_dice.sum()
         losses["loss_iou"] += loss_iou.sum()
+        losses["loss_div"] += loss_div.sum()
         losses["loss_class"] += loss_class
 
     def reduce_loss(self, losses):

--- a/training/loss_fns.py
+++ b/training/loss_fns.py
@@ -33,7 +33,7 @@ def dice_loss(inputs, targets, num_objects):
     denominator = inputs.sum(-1) + targets.sum(-1)
     loss = 1 - (numerator + 1) / (denominator + 1)
 
-    return loss.sum() / num_objects
+    return loss / num_objects
 
 
 def sigmoid_focal_loss(
@@ -68,7 +68,7 @@ def sigmoid_focal_loss(
         alpha_t = alpha * targets + (1 - alpha) * (1 - targets)
         loss = alpha_t * loss
 
-    return loss.mean(1).sum() / num_objects
+    return loss.flatten(1).mean(-1) / num_objects
 
 
 def iou_loss(
@@ -98,7 +98,7 @@ def iou_loss(
         loss = F.l1_loss(pred_ious, actual_ious, reduction="none")
     else:
         loss = F.mse_loss(pred_ious, actual_ious, reduction="none")
-    return loss.sum() / num_objects
+    return loss / num_objects
 
 
 class MultiStepMultiMasksAndIous(nn.Module):
@@ -257,7 +257,7 @@ class MultiStepMultiMasksAndIous(nn.Module):
         losses["loss_dice"] += loss_dice.sum()
         losses["loss_iou"] += loss_iou.sum()
         losses["loss_div"] += loss_div.sum()
-        losses["loss_class"] += loss_class
+        losses["loss_class"] += loss_class.sum()
 
     def reduce_loss(self, losses):
         reduced_loss = 0.0

--- a/training/loss_fns.py
+++ b/training/loss_fns.py
@@ -225,17 +225,13 @@ class MultiStepMultiMasksAndIous(nn.Module):
                 gamma=self.focal_gamma_obj_score,
             )
 
-        num_dividing_objects = target_divide.sum()
-        if num_dividing_objects > 0:
-            loss_div = sigmoid_focal_loss(
-                div_score_logits,
-                target_divide[:,None].to(torch.float),
-                num_objects,
-                alpha=self.focal_alpha_obj_score,
-                gamma=self.focal_gamma_obj_score,
-            )
-        else:
-            loss_div = torch.zeros_like(div_score_logits)
+        loss_div = sigmoid_focal_loss(
+            div_score_logits,
+            target_divide[:,None].to(torch.float),
+            num_objects,
+            alpha=self.focal_alpha_obj_score,
+            gamma=self.focal_gamma_obj_score,
+        )
 
         loss_iou = iou_loss(
             src_masks,
@@ -249,7 +245,6 @@ class MultiStepMultiMasksAndIous(nn.Module):
         loss_mask = loss_mask * post_div_target_obj
         loss_dice = loss_dice * post_div_target_obj
         loss_iou = loss_iou * post_div_target_obj
-        loss_div = loss_div * pre_div_target_obj
 
         # sum over batch dimension (note that the losses are already divided by num_objects)
         losses["loss_mask"] += loss_mask.sum()

--- a/training/loss_fns.py
+++ b/training/loss_fns.py
@@ -225,13 +225,12 @@ class MultiStepMultiMasksAndIous(nn.Module):
                 gamma=self.focal_gamma_obj_score,
             )
 
-
         num_dividing_objects = target_divide.sum()
         if num_dividing_objects > 0:
             loss_div = sigmoid_focal_loss(
                 div_score_logits,
                 target_divide[:,None].to(torch.float),
-                num_dividing_objects,
+                num_objects,
                 alpha=self.focal_alpha_obj_score,
                 gamma=self.focal_gamma_obj_score,
             )

--- a/training/model/sam2.py
+++ b/training/model/sam2.py
@@ -291,6 +291,9 @@ class SAM2Train(SAM2Base):
         all_frame_outputs = {}
 
         for stage_id in processing_order:
+            if input.no_inputs[stage_id]:
+                continue
+
             # Get the image features for the current frames
             # img_ids = input.find_inputs[stage_id].img_ids
             img_ids = input.flat_obj_to_img_idx[stage_id]
@@ -330,7 +333,7 @@ class SAM2Train(SAM2Base):
             all_frame_outputs[stage_id] = current_out
 
         # turn `output_dict` into a list for loss function
-        all_frame_outputs = [all_frame_outputs[t] for t in range(num_frames)]
+        all_frame_outputs = [all_frame_outputs[t] for t in range(num_frames) if not input.no_inputs[t]]
         # Make DDP happy with activation checkpointing by removing unused keys
         all_frame_outputs = [
             {k: v for k, v in d.items() if k != "obj_ptr"} for d in all_frame_outputs

--- a/training/model/sam2.py
+++ b/training/model/sam2.py
@@ -390,9 +390,9 @@ class SAM2Train(SAM2Base):
             mask_inputs,
             num_frames,
             prev_sam_mask_logits,
-            is_dividing,
             tracking_object_ids,
             memory_dict,
+            is_dividing,
             gt_masks
         )
 
@@ -402,9 +402,8 @@ class SAM2Train(SAM2Base):
             low_res_masks,
             high_res_masks,
             obj_ptr,
-            object_score_logits,
+            object_score_logits_dict,
             div_score_logits,
-            post_split_object_score_logits,
             is_dividing,
         ) = sam_outputs
 
@@ -415,9 +414,8 @@ class SAM2Train(SAM2Base):
             high_res_masks,
             ious,
             point_inputs,
-            object_score_logits,
+            object_score_logits_dict,
             div_score_logits,
-            post_split_object_score_logits
         )
 
         # Handle cell tracking and division
@@ -476,18 +474,18 @@ class SAM2Train(SAM2Base):
         high_res_masks,
         ious,
         point_inputs,
-        object_score_logits,
+        object_score_logits_dict,
         div_score_logits,
-        post_split_object_score_logits
     ):
+        
         """Store prediction results in the output dictionary."""
         current_out["multistep_pred_masks"] = [low_res_masks]
         current_out["multistep_pred_masks_high_res"] = [high_res_masks]
         current_out["multistep_pred_ious"] = [ious]
         current_out["multistep_point_inputs"] = [point_inputs]
-        current_out["multistep_object_score_logits"] = [object_score_logits]
+        current_out["multistep_object_score_logits"] = [object_score_logits_dict["pre_div"]]
         current_out["multistep_div_score_logits"] = [div_score_logits]
-        current_out["post_split_object_score_logits"] = [post_split_object_score_logits]
+        current_out["post_split_object_score_logits"] = [object_score_logits_dict["post_div"]]
         
     def _handle_cell_tracking(
         self,
@@ -749,9 +747,8 @@ class SAM2Train(SAM2Base):
                 low_res_masks,
                 high_res_masks,
                 obj_ptr,
-                object_score_logits,
+                object_score_logits_dict,
                 div_score_logits,
-                post_split_object_score_logits,
                 is_dividing,
             ) = sam_outputs
             
@@ -760,9 +757,9 @@ class SAM2Train(SAM2Base):
             current_out["multistep_pred_masks_high_res"].append(high_res_masks)
             current_out["multistep_pred_ious"].append(ious)
             current_out["multistep_point_inputs"].append(point_inputs)
-            current_out["multistep_object_score_logits"].append(object_score_logits)
+            current_out["multistep_object_score_logits"].append(object_score_logits_dict["pre_div"])
             current_out["multistep_div_score_logits"].append(div_score_logits)
-            current_out["post_split_object_score_logits"].append(post_split_object_score_logits)
+            current_out["post_split_object_score_logits"].append(object_score_logits_dict["post_div"])
             current_out["multistep_is_point_used"].append(keep_tokens_mask)
             
             current_out["pre_div_target_obj"].append(current_out["pre_div_target_obj"][0].clone())

--- a/training/model/sam2.py
+++ b/training/model/sam2.py
@@ -539,8 +539,8 @@ class SAM2Train(SAM2Base):
         exit_object_ids = tracking_object_ids[~keep_tokens_mask]
         tracking_object_ids = tracking_object_ids[keep_tokens_mask]
         
-        if frame_idx % 10 == 0:  # Reduce logging frequency
-            logging.debug(f'Frame: {frame_idx} | Tracking IDs: {tracking_object_ids} | Exit IDs: {exit_object_ids}')
+        # if frame_idx % 10 == 0:  # Reduce logging frequency
+        #     logging.debug(f'Frame: {frame_idx} | Tracking IDs: {tracking_object_ids} | Exit IDs: {exit_object_ids}')
         
         # Update object pointers
         obj_ptrs = obj_ptr[keep_tokens_mask]

--- a/training/model/sam2.py
+++ b/training/model/sam2.py
@@ -418,6 +418,8 @@ class SAM2Train(SAM2Base):
             div_score_logits,
         )
 
+        current_out["heatmap_predictions"] = self.get_heatmap_predictions(current_vision_feats, feat_sizes)[0,0] # assume batch size is 1
+
         # Handle cell tracking and division
         keep_tokens_mask, tracking_object_ids, mother_ids, prev_tracking_object_ids = self._handle_cell_tracking(
             current_out,

--- a/training/model/sam2.py
+++ b/training/model/sam2.py
@@ -287,7 +287,7 @@ class SAM2Train(SAM2Base):
         processing_order = init_cond_frames + backbone_out["frames_not_in_init_cond"]
 
         tracking_object_ids = input.metadata.unique_objects_identifier[0][:,1]
-        memory_dict = {}
+        memory_dict = {'mask_mem_pos_enc': None}
         all_frame_outputs = {}
 
         for stage_id in processing_order:

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -482,6 +482,8 @@ class Trainer:
         outputs = model(batch)
         targets, target_divide = batch.masks, batch.cell_divides
         batch_size = len(batch.img_batch)
+        targets = [target for target, no_inputs in zip(targets, batch.no_inputs) if not no_inputs]
+        target_divide = [target_divide for target_divide, no_inputs in zip(target_divide, batch.no_inputs) if not no_inputs]
 
         key = batch.dict_key  # key for dataset
         loss = self.loss[key](outputs, targets, target_divide)

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -655,6 +655,7 @@ class Trainer:
             batch.cell_tracks_mask = [cell_tracks_mask.to(self.device) for cell_tracks_mask in batch.cell_tracks_mask]
             batch.daughter_ids = [daughter_ids.to(self.device) for daughter_ids in batch.daughter_ids]
             batch.obj_to_frame_idx = [obj_to_frame_idx.to(self.device) for obj_to_frame_idx in batch.obj_to_frame_idx]
+            batch.target_obj_mask = [target_obj_mask.to(self.device) for target_obj_mask in batch.target_obj_mask]
             batch.metadata.unique_objects_identifier = [unique_objects_identifier.to(self.device) for unique_objects_identifier in batch.metadata.unique_objects_identifier]
 
             # compute output
@@ -808,6 +809,7 @@ class Trainer:
             batch.cell_tracks_mask = [cell_tracks_mask.to(self.device) for cell_tracks_mask in batch.cell_tracks_mask]
             batch.daughter_ids = [daughter_ids.to(self.device) for daughter_ids in batch.daughter_ids]
             batch.obj_to_frame_idx = [obj_to_frame_idx.to(self.device) for obj_to_frame_idx in batch.obj_to_frame_idx]
+            batch.target_obj_mask = [target_obj_mask.to(self.device) for target_obj_mask in batch.target_obj_mask]
             batch.metadata.unique_objects_identifier = [unique_objects_identifier.to(self.device) for unique_objects_identifier in batch.metadata.unique_objects_identifier]
 
             try:

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -333,13 +333,12 @@ class Trainer:
     def save_checkpoint(self, epoch, checkpoint_names=None):
         checkpoint_folder = self.checkpoint_conf.save_dir
         makedir(checkpoint_folder)
-        if checkpoint_names is None:
-            checkpoint_names = ["checkpoint"]
-            if (
-                self.checkpoint_conf.save_freq > 0
-                and (int(epoch) % self.checkpoint_conf.save_freq == 0)
-            ) or int(epoch) in self.checkpoint_conf.save_list:
-                checkpoint_names.append(f"checkpoint_{int(epoch)}")
+        checkpoint_names = ["checkpoint"]
+        if (
+            self.checkpoint_conf.save_freq > 0
+            and (int(epoch) % self.checkpoint_conf.save_freq == 0)
+        ) or int(epoch) in self.checkpoint_conf.save_list:
+            checkpoint_names.append(f"checkpoint_{int(epoch)}")
 
         checkpoint_paths = []
         for ckpt_name in checkpoint_names:

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -481,11 +481,11 @@ class Trainer:
     ):
 
         outputs = model(batch)
-        targets = batch.masks
+        targets, target_divide = batch.masks, batch.cell_divides
         batch_size = len(batch.img_batch)
 
         key = batch.dict_key  # key for dataset
-        loss = self.loss[key](outputs, targets)
+        loss = self.loss[key](outputs, targets, target_divide)
         loss_str = f"Losses/{phase}_{key}_loss"
 
         loss_log_str = os.path.join("Step_Losses", loss_str)

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -479,7 +479,6 @@ class Trainer:
         model: nn.Module,
         phase: str,
     ):
-
         outputs = model(batch)
         targets, target_divide = batch.masks, batch.cell_divides
         batch_size = len(batch.img_batch)
@@ -646,6 +645,15 @@ class Trainer:
             data_time.update(time.time() - end)
 
             batch = batch.to(self.device, non_blocking=True)
+            
+            # These are tensors within lists so the general .to(self.device) only works for the img_batch
+            batch.masks = [masks.to(self.device) for masks in batch.masks]
+            batch.bkgd_masks = [bkgd_masks.to(self.device) for bkgd_masks in batch.bkgd_masks]
+            batch.cell_divides = [cell_divides.to(self.device) for cell_divides in batch.cell_divides]
+            batch.cell_tracks_mask = [cell_tracks_mask.to(self.device) for cell_tracks_mask in batch.cell_tracks_mask]
+            batch.daughter_ids = [daughter_ids.to(self.device) for daughter_ids in batch.daughter_ids]
+            batch.obj_to_frame_idx = [obj_to_frame_idx.to(self.device) for obj_to_frame_idx in batch.obj_to_frame_idx]
+            batch.metadata.unique_objects_identifier = [unique_objects_identifier.to(self.device) for unique_objects_identifier in batch.metadata.unique_objects_identifier]
 
             # compute output
             with torch.no_grad():
@@ -790,6 +798,15 @@ class Trainer:
             batch = batch.to(
                 self.device, non_blocking=True
             )  # move tensors in a tensorclass
+
+            # These are tensors within lists so the general .to(self.device) only works for the img_batch
+            batch.masks = [masks.to(self.device) for masks in batch.masks]
+            batch.bkgd_masks = [bkgd_masks.to(self.device) for bkgd_masks in batch.bkgd_masks]
+            batch.cell_divides = [cell_divides.to(self.device) for cell_divides in batch.cell_divides]
+            batch.cell_tracks_mask = [cell_tracks_mask.to(self.device) for cell_tracks_mask in batch.cell_tracks_mask]
+            batch.daughter_ids = [daughter_ids.to(self.device) for daughter_ids in batch.daughter_ids]
+            batch.obj_to_frame_idx = [obj_to_frame_idx.to(self.device) for obj_to_frame_idx in batch.obj_to_frame_idx]
+            batch.metadata.unique_objects_identifier = [unique_objects_identifier.to(self.device) for unique_objects_identifier in batch.metadata.unique_objects_identifier]
 
             try:
                 self._run_step(batch, phase, loss_mts, extra_loss_mts)

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -480,13 +480,14 @@ class Trainer:
         phase: str,
     ):
         outputs = model(batch)
-        targets, target_divide = batch.masks, batch.cell_divides
+        targets, target_divide, target_heatmaps = batch.masks, batch.cell_divides, batch.heatmaps
         batch_size = len(batch.img_batch)
         targets = [target for target, no_inputs in zip(targets, batch.no_inputs) if not no_inputs]
         target_divide = [target_divide for target_divide, no_inputs in zip(target_divide, batch.no_inputs) if not no_inputs]
+        target_heatmaps = [target_heatmaps for target_heatmaps, no_inputs in zip(target_heatmaps, batch.no_inputs) if not no_inputs]
 
         key = batch.dict_key  # key for dataset
-        loss = self.loss[key](outputs, targets, target_divide)
+        loss = self.loss[key](outputs, targets, target_divide, target_heatmaps)
         loss_str = f"Losses/{phase}_{key}_loss"
 
         loss_log_str = os.path.join("Step_Losses", loss_str)
@@ -657,6 +658,7 @@ class Trainer:
             batch.obj_to_frame_idx = [obj_to_frame_idx.to(self.device) for obj_to_frame_idx in batch.obj_to_frame_idx]
             batch.target_obj_mask = [target_obj_mask.to(self.device) for target_obj_mask in batch.target_obj_mask]
             batch.metadata.unique_objects_identifier = [unique_objects_identifier.to(self.device) for unique_objects_identifier in batch.metadata.unique_objects_identifier]
+            batch.heatmaps = [heatmaps.to(self.device) for heatmaps in batch.heatmaps]
 
             # compute output
             with torch.no_grad():
@@ -811,6 +813,7 @@ class Trainer:
             batch.obj_to_frame_idx = [obj_to_frame_idx.to(self.device) for obj_to_frame_idx in batch.obj_to_frame_idx]
             batch.target_obj_mask = [target_obj_mask.to(self.device) for target_obj_mask in batch.target_obj_mask]
             batch.metadata.unique_objects_identifier = [unique_objects_identifier.to(self.device) for unique_objects_identifier in batch.metadata.unique_objects_identifier]
+            batch.heatmaps = [heatmaps.to(self.device) for heatmaps in batch.heatmaps]
 
             try:
                 self._run_step(batch, phase, loss_mts, extra_loss_mts)

--- a/training/utils/checkpoint_utils.py
+++ b/training/utils/checkpoint_utils.py
@@ -357,12 +357,12 @@ def load_state_dict_into_model(
             state_dict = f(state_dict=state_dict)
     missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
 
-    check_load_state_dict_errors(
-        missing_keys,
-        unexpected_keys,
-        strict=strict,
-        model=model,
-        ignore_missing_keys=ignore_missing_keys,
-        ignore_unexpected_keys=ignore_unexpected_keys,
-    )
+    # check_load_state_dict_errors(
+    #     missing_keys,
+    #     unexpected_keys,
+    #     strict=strict,
+    #     model=model,
+    #     ignore_missing_keys=ignore_missing_keys,
+    #     ignore_unexpected_keys=ignore_unexpected_keys,
+    # )
     return model

--- a/training/utils/data_utils.py
+++ b/training/utils/data_utils.py
@@ -50,6 +50,9 @@ class BatchedVideoDatapoint:
     metadata: BatchedVideoMetaData
     bkgd_masks: torch.BoolTensor
     dict_key: str
+    cell_divides: torch.IntTensor
+    cell_tracks_mask: torch.BoolTensor
+    daughter_ids: torch.IntTensor
 
     def pin_memory(self, device=None):
         return self.apply(torch.Tensor.pin_memory, device=device)
@@ -74,8 +77,15 @@ class BatchedVideoDatapoint:
         Returns a flattened tensor containing the object to img index.
         The flat index can be used to access a flattened img_batch of shape [(T*B)xCxHxW]
         """
-        frame_idx, video_idx = self.obj_to_frame_idx.unbind(dim=-1)
-        flat_idx = video_idx * self.num_frames + frame_idx
+
+        flat_idx = []
+
+        for i in range(len(self.obj_to_frame_idx)):
+            batch = self.obj_to_frame_idx[i]
+            frame_idx = batch[:,0]
+            video_idx = batch[:,1]
+            flat_idx.append(video_idx * self.num_frames + frame_idx)
+
         return flat_idx
 
     @property
@@ -94,12 +104,16 @@ class Object:
     # Index of the frame in the media (0 if single image)
     frame_index: int
     segment: Union[torch.Tensor, dict]  # RLE dict or binary mask
-
+    entering: Optional[bool] = None
+    parent_id: Optional[int] = None
+    daughter_ids: Optional[torch.Tensor] = None
+    is_in_next_object_ids_list: Optional[bool] = None
 
 @dataclass
 class Frame:
     data: Union[torch.Tensor, PILImage.Image]
     objects: List[Object]
+    object_ids: List[int]
 
 
 @dataclass
@@ -109,7 +123,7 @@ class VideoDatapoint:
     frames: List[Frame]
     video_id: int
     size: Tuple[int, int]
-
+    man_track: torch.IntTensor
 
 def collate_fn(
     batch: List[VideoDatapoint],
@@ -135,42 +149,80 @@ def collate_fn(
         [] for _ in range(T)
     ]  # List to store frame indices for each time step
 
-    bkgd_masks = torch.zeros(T,B,H,W,device=img_batch.device)
+    bkgd_masks = torch.zeros(T,B,H,W,device=img_batch.device, dtype=torch.bool)
+
+    step_t_cell_divides = [[] for _ in range(T)]
+    step_t_cell_tracks_mask = [[] for _ in range(T)]
+    step_t_daughter_ids = [[] for _ in range(T)]
 
     for video_idx, video in enumerate(batch):
         orig_video_id = video.video_id
         orig_frame_size = video.size
         for t, frame in enumerate(video.frames):
             objects = frame.objects
+            dividing_masks = {}
             for obj in objects:
                 if obj.object_id == -1000:
                     bkgd_masks[t,video_idx] += obj.segment
                     continue
+
+                # Divided cells are only used for the masks since the mother cells are the inputs to the frame
+                if t > 0 and obj.entering and obj.parent_id > 0:                      
+                    dividing_masks[obj.object_id] = obj.segment.to(torch.bool)
+                    continue 
+
+                if obj.daughter_ids.sum() > 0:
+                    step_t_daughter_ids[t].append(obj.daughter_ids)
+                else:
+                    step_t_daughter_ids[t].append(torch.zeros((2), dtype=torch.int32))
+
                 orig_obj_id = obj.object_id
                 orig_frame_idx = obj.frame_index
                 step_t_obj_to_frame_idx[t].append(
                     torch.tensor([t, video_idx], dtype=torch.int)
                 )
-                step_t_masks[t].append(obj.segment.to(torch.bool))
+
+                # Skip the mask of the mother cell dividing since we will use the daugher cells masks instead
+                # The mother cell is the input and the daughter cells are the outputs
+                if obj.daughter_ids.sum() == 0:
+                    step_t_masks[t].append(obj.segment.to(torch.bool))
+
                 step_t_objects_identifier[t].append(
                     torch.tensor([orig_video_id, orig_obj_id, orig_frame_idx])
                 )
                 step_t_frame_orig_size[t].append(torch.tensor(orig_frame_size))
 
-    obj_to_frame_idx = torch.stack(
-        [
-            torch.stack(obj_to_frame_idx, dim=0)
-            for obj_to_frame_idx in step_t_obj_to_frame_idx
-        ],
-        dim=0,
-    )
-    masks = torch.stack([torch.stack(masks, dim=0) for masks in step_t_masks], dim=0)
-    objects_identifier = torch.stack(
-        [torch.stack(id, dim=0) for id in step_t_objects_identifier], dim=0
-    )
-    frame_orig_size = torch.stack(
-        [torch.stack(id, dim=0) for id in step_t_frame_orig_size], dim=0
-    )
+                step_t_cell_divides[t].append(obj.daughter_ids.sum() > 0)
+
+                # This signifies that a cell is being tracked to the next frame regardless if it exists in the next frame or not
+                # This keeps track of cells being tracked after exiting the current frame for VOSSampler.num_frames_track_lost_objects frames
+                # The VOS Sampler decides the number of frames we track object after it exits
+                step_t_cell_tracks_mask[t].append((obj.is_in_next_object_ids_list))
+
+            for daughter_ids in step_t_daughter_ids[t]:
+                if daughter_ids.sum() > 0:
+                    for daughter_id in daughter_ids:
+                        step_t_masks[t].append(dividing_masks[int(daughter_id)])
+
+    # Handle empty lists to prevent stack errors
+    for t in range(T):
+        if not step_t_obj_to_frame_idx[t]:
+            step_t_obj_to_frame_idx[t].append(torch.tensor([t, 0], dtype=torch.int))
+            step_t_masks[t].append(torch.zeros((H, W), dtype=torch.bool, device=img_batch.device))
+            step_t_objects_identifier[t].append(torch.tensor([0, 0, 0]))
+            step_t_frame_orig_size[t].append(torch.tensor([H, W]))
+            step_t_cell_divides[t].append(False)
+            step_t_cell_tracks_mask[t].append(False)
+            step_t_daughter_ids[t].append(torch.zeros((2), dtype=torch.int32))
+
+    obj_to_frame_idx = [torch.stack(obj_to_frame_idx, dim=0) for obj_to_frame_idx in step_t_obj_to_frame_idx]
+    masks = [torch.stack(masks, dim=0) for masks in step_t_masks]
+    objects_identifier = [torch.stack(id, dim=0) for id in step_t_objects_identifier]
+    frame_orig_size = [torch.stack(id, dim=0) for id in step_t_frame_orig_size]
+    cell_divides = [torch.stack(id, dim=0) for id in step_t_cell_divides]
+    cell_tracks_mask = [torch.tensor(id, dtype=torch.bool) for id in step_t_cell_tracks_mask]
+    daughter_ids = [torch.stack(id, dim=0) for id in step_t_daughter_ids]
+    
     return BatchedVideoDatapoint(
         img_batch=img_batch,
         obj_to_frame_idx=obj_to_frame_idx,
@@ -180,6 +232,9 @@ def collate_fn(
             frame_orig_size=frame_orig_size,
         ),
         bkgd_masks=bkgd_masks,
+        cell_divides=cell_divides,
+        cell_tracks_mask=cell_tracks_mask,
+        daughter_ids=daughter_ids,
         dict_key=dict_key,
         batch_size=[T],
     )

--- a/training/utils/data_utils.py
+++ b/training/utils/data_utils.py
@@ -55,7 +55,7 @@ class BatchedVideoDatapoint:
     daughter_ids: torch.IntTensor
     no_inputs: torch.BoolTensor
     target_obj_mask: torch.BoolTensor
-    
+
     def pin_memory(self, device=None):
         return self.apply(torch.Tensor.pin_memory, device=device)
 
@@ -201,7 +201,7 @@ def collate_fn(
                 # This keeps track of cells being tracked after exiting the current frame for VOSSampler.num_frames_track_lost_objects frames
                 # The VOS Sampler decides the number of frames we track object after it exits
                 step_t_cell_tracks_mask[t].append((obj.is_in_next_object_ids_list))
-                step_t_target_obj_mask[t].append(obj.segment.sum() > 0)
+                step_t_target_obj_mask[t].append(obj.segment.sum() > 0 or obj.daughter_ids.sum() > 0)
 
             for daughter_ids in step_t_daughter_ids[t]:
                 if daughter_ids.sum() > 0:

--- a/training/utils/data_utils.py
+++ b/training/utils/data_utils.py
@@ -149,7 +149,7 @@ def collate_fn(
         [] for _ in range(T)
     ]  # List to store frame indices for each time step
 
-    bkgd_masks = torch.zeros(T,B,H,W,device=img_batch.device, dtype=torch.bool)
+    bkgd_masks = torch.zeros(T,B,H,W, dtype=torch.bool)
 
     step_t_cell_divides = [[] for _ in range(T)]
     step_t_cell_tracks_mask = [[] for _ in range(T)]
@@ -163,7 +163,7 @@ def collate_fn(
             dividing_masks = {}
             for obj in objects:
                 if obj.object_id == -1000:
-                    bkgd_masks[t,video_idx] += obj.segment
+                    bkgd_masks[t,video_idx] += obj.segment.to(torch.bool)
                     continue
 
                 # Divided cells are only used for the masks since the mother cells are the inputs to the frame
@@ -208,7 +208,7 @@ def collate_fn(
     for t in range(T):
         if not step_t_obj_to_frame_idx[t]:
             step_t_obj_to_frame_idx[t].append(torch.tensor([t, 0], dtype=torch.int))
-            step_t_masks[t].append(torch.zeros((H, W), dtype=torch.bool, device=img_batch.device))
+            step_t_masks[t].append(torch.zeros((H, W), dtype=torch.bool))
             step_t_objects_identifier[t].append(torch.tensor([0, 0, 0]))
             step_t_frame_orig_size[t].append(torch.tensor([H, W]))
             step_t_cell_divides[t].append(False)


### PR DESCRIPTION
CellSam2 can now perform multi-object tracking with cells. The model can track cells, predict divisions, predict new cells and drop cells that are not predicted to exist in the frame. Different from SAM2, I add a heatmap predictor head that predicts where cells are located in the image. These predictions can be converted into points or centroids and fed to the model to predict the cell. During inference, this is used to predict new cells and help with error correction. In addition, this can be used during segmentation instead of a point grid that is inefficient and can still miss cells in my experience.

SAM2 predicts 4 masks. The first mask is used by default. If use_multimask_outputs=True then the last 3 masks will be used and the top iou predicted mask will be selected. This is helpful for ambigious input points for segmentation where you may want to segment the whole person or just their face. However, for cells it is not ambigious and not necessary. However, I take advantage of this architecture for cell divison. If a cell is detected or tracked, the model uses the first mask; if a cell divides, the model uses the first two masks of the mulitmask outputs. This way, if the model is unsure about division, the multimask masks can predict the two daugher masks and the first mask (not multimask) can predict the mask as if it never divides. Then a division token can predict where a division is occurring and will determine where mask(s) are selected.